### PR TITLE
add cmd take-ownership

### DIFF
--- a/oar/cli/cmd_create_test_report.py
+++ b/oar/cli/cmd_create_test_report.py
@@ -24,5 +24,4 @@ def create_test_report(ctx):
 
     logger.info(f"new test report is created: {report.get_url()}")
 
-    # TODO: update assignee of JIRA tasks
     # TODO: send email to QE and ART

--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -2,12 +2,14 @@ import click
 import logging
 import oar.core.util as util
 from oar.cli.cmd_create_test_report import create_test_report
+from oar.cli.cmd_take_ownership import take_ownership
 from oar.core.config_store import ConfigStore, ConfigStoreException
+from oar.core.const import CONTEXT_SETTINGS
 
 logger = logging.getLogger(__name__)
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.pass_context
 @click.option("-r", "--release", help="z-stream releaes version", required=True)
 @click.option("-v", "--debug", help="enable debug logging", is_flag=True, default=False)
@@ -23,3 +25,4 @@ def cli(ctx, release, debug):
 
 
 cli.add_command(create_test_report)
+cli.add_command(take_ownership)

--- a/oar/cli/cmd_take_ownership.py
+++ b/oar/cli/cmd_take_ownership.py
@@ -1,0 +1,57 @@
+import click
+import logging
+import oar.core.util as util
+from oar.core.worksheet_mgr import WorksheetManager, WorksheetException
+from oar.core.jira_mgr import JiraManager, JiraException
+from oar.core.advisory_mgr import AdvisoryManager, AdvisoryException
+from oar.core.config_store import ConfigStore
+from oar.core.const import *
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "-e",
+    "--email",
+    help="email address of the owner, if option is not set, will use default owner setting instead",
+)
+@click.pass_context
+def take_ownership(ctx, email):
+    """
+    Take ownership for advisory and jira subtasks
+    """
+    # get config store from context
+    cs = ctx.obj["cs"]
+    if not email:
+        logger.warn("email option is not set, will use default setting")
+    else:
+        cs.set_owner(email)
+    # init worksheet manager
+    try:
+        wm = WorksheetManager(cs)
+        report = wm.get_test_report()
+        report.update_task_status(LABEL_TASK_OWNERSHIP, TASK_STATUS_INPROGRESS)
+    except WorksheetException as we:
+        logger.exception("get test report failed")
+        raise
+
+    # update assignee of QE subtasks and change status of test verification ticket to in_progress
+    try:
+        JiraManager(cs).change_assignee_of_qe_subtasks()
+    except JiraException as je:
+        logger.exception("change assignee of qe subtasks failed")
+        raise
+
+    # update owner of advisories which status is QE
+    try:
+        AdvisoryManager(cs).change_ad_owners()
+    except AdvisoryException as ae:
+        logger.exception("change qe owner of advisory failed")
+        raise
+
+    try:
+        report.update_task_status(LABEL_TASK_OWNERSHIP, TASK_STATUS_PASS)
+    except WorksheetException as we:
+        logger.exception("update task status failed")
+        raise

--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -2,6 +2,9 @@ from errata_tool import Erratum
 from errata_tool import ErrataException
 from oar.core.config_store import ConfigStore
 from oar.core.exceptions import AdvisoryException
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class AdvisoryManager:
@@ -13,6 +16,23 @@ class AdvisoryManager:
     def __init__(self, cs: ConfigStore):
         self._cs = cs
 
+    def get_advisories(self):
+        """
+        Get all advisories
+
+        Returns:
+            []Advisory: all advisoriy wrappers
+        """
+        ads = []
+        for k, v in self._cs.get_advisories().items():
+            ad = Advisory(
+                errata_id=v,
+                impetus=k,
+            )
+            ads.append(ad)
+
+        return ads
+
     def get_jira_issues(self):
         """
         Get all jira issues from advisories in a release
@@ -21,15 +41,29 @@ class AdvisoryManager:
             []: all jira issues from advisories
         """
         all_jira_issues = []
-        ads = self._cs.get_advisories()
-        for k, v in ads.items():
-            ad = Advisory(
-                errata_id=v,
-                impetus=k,
-            )
-            all_jira_issues += ad.jira_issues
+        try:
+            for ad in self.get_advisories():
+                all_jira_issues += ad.jira_issues
+        except ErrataException as e:
+            raise AdvisoryException("get jira issue from advisory failed") from e
 
         return all_jira_issues
+
+    def change_ad_owners(self):
+        """
+        Change QA owner of all the advisories
+
+        Raises:
+            AdvisoryException: _description_
+        """
+        try:
+            for ad in self.get_advisories():
+                # check advisory status, if it is not QE, log warn message
+                if ad.errata_state != "QE":
+                    logger.warn(f"advisory state is not QE, it is {ad.errata_state}")
+                ad.change_qe_email(self._cs.get_owner())
+        except ErrataException as e:
+            raise AdvisoryException("change advisory owner failed") from e
 
 
 class Advisory(Erratum):
@@ -44,3 +78,20 @@ class Advisory(Erratum):
             super().__init__(**kwargs)
         except ErrataException as e:
             raise AdvisoryException("initialize erratum failed") from e
+
+    def change_qe_email(self, email):
+        """
+        Change advisory owner
+
+        Args:
+            email (str): owner's email address
+        """
+        self.update(qe_email=email)
+        self.commit()
+        logger.info(f"qe email of advisory {self.errata_id} is updated to {email}")
+
+    def get_qe_email(self):
+        """
+        Get qe email of this advisory
+        """
+        return self.qe_email

--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -88,7 +88,7 @@ class Advisory(Erratum):
         """
         self.update(qe_email=email)
         self.commit()
-        logger.info(f"qe email of advisory {self.errata_id} is updated to {email}")
+        logger.info(f"QA Owner of advisory {self.errata_id} is updated to {email}")
 
     def get_qe_email(self):
         """

--- a/oar/core/config_store.py
+++ b/oar/core/config_store.py
@@ -37,8 +37,6 @@ class ConfigStore:
         with open(path) as f:
             self._local_conf = json.load(f)
 
-        logger.info("local config is loaded")
-
         # download ocp build data with release branch e.g. openshift-4.12
         branch = "openshift-%s" % util.get_y_release(self.release)
         url = self._local_conf["build_data_url"] % branch
@@ -48,8 +46,6 @@ class ConfigStore:
             response.raise_for_status()
         except RequestException as re:
             raise ConfigStoreException("download ocp build data failed") from re
-
-        logger.info(f"ocp build data of {release} is downloaded")
 
         if response.text:
             try:
@@ -93,6 +89,15 @@ class ConfigStore:
         """
         return self._assembly["group"]["release_jira"]
 
+    def set_jira_ticket(self, key):
+        """
+        Overwrite default jira ticket
+
+        Args:
+            key (str): jira ticket created by art team
+        """
+        self._assembly["group"]["release_jira"] = key
+
     def get_owner(self):
         """
         Get advisory owner setting from local config
@@ -104,6 +109,14 @@ class ConfigStore:
             return o["default"]
         else:
             return o[yr]
+
+    def set_owner(self, email):
+        """
+        Overwrite owner
+        """
+        o = self._local_conf["owners"]
+        yr = util.get_y_release(self.release)
+        o[yr] = email
 
     def get_slack_contact(self, team):
         """

--- a/oar/core/const.py
+++ b/oar/core/const.py
@@ -1,3 +1,5 @@
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
 # cell labels
 LABEL_ADVISORY = "B2"
 LABEL_BUILD = "B3"
@@ -38,3 +40,8 @@ JIRA_STATUS_CLOSED = "Closed"
 JIRA_STATUS_IN_PROGRESS = "In Progress"
 JIRA_STATUS_VERIFIED = "Verified"
 JIRA_STATUS_ON_QA = "ON_QA"
+JIRA_QE_TASK_SUMMARIES = [
+    "[Fri/Mon] QE moves advisories to REL_PREP",
+    "[Wed-Fri] QE does release verification",
+    "[Mon-Wed] QE notifies ON_QA bugzilla owners and analyze ci failures",
+]

--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -20,4 +20,4 @@ class TestAdvisoryManager(unittest.TestCase):
     def test_change_qe_owner(self):
         self.am.change_ad_owners()
         for ad in self.am.get_advisories():
-            self.assertEqual(ad.get_qe_email(), "huirwang@redhat.com")
+            self.assertEqual(ad.get_qe_email(), "xx@redhat.com")

--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -15,3 +15,9 @@ class TestAdvisoryManager(unittest.TestCase):
         jira_issues = self.am.get_jira_issues()
         self.assertIn("OCPBUGS-10973", jira_issues)
         self.assertIn("OCPBUGS-10225", jira_issues)
+
+    @unittest.skip("disable this case, will not update released advisory")
+    def test_change_qe_owner(self):
+        self.am.change_ad_owners()
+        for ad in self.am.get_advisories():
+            self.assertEqual(ad.get_qe_email(), "huirwang@redhat.com")


### PR DESCRIPTION
add cmd implementation of `take-ownership`
- init config store
- get existing test report
- update task status to `In Progress` in test report
- get subtasks of jira story created by art team
- filter out QE subtasks
- get owner email from cmd option, if it is not set,  get it from config store
- update assignee of QE subtasks
- get all advisories
- check errata state of the advisory. if it is not `QE` log a warning message
- update qe email of advisories to owner email
- update task status to `Pass` in test report

cmd help
```
./cli -r 4.12.11 take-ownership -h
Usage: cli take-ownership [OPTIONS]

  Take ownership for advisory and jira subtasks

Options:
  -e, --email TEXT  email address of the owner, if option is not set, will use
                    default owner setting instead
  -h, --help        Show this message and exit.
```
cmd output
```
./cli -r 4.12.11 take-ownership
2023-05-17T16:08:45Z: WARNING: email option is not set, will use default setting
2023-05-17T16:08:49Z: INFO: task [Take ownership of advisories] status is changed to [In Progress]
2023-05-17T16:08:52Z: INFO: found subtask ART-6490 - release blocker indicator
2023-05-17T16:08:53Z: INFO: found subtask ART-6491 - [Wed] Prepare the release
2023-05-17T16:08:54Z: INFO: found subtask ART-6492 - [Wed-Fri] QE does release verification
2023-05-17T16:08:54Z: INFO: found subtask ART-6493 - [Wed] Promote the tested nightly to 4-stable in CI and sign
2023-05-17T16:08:55Z: INFO: found subtask ART-6494 - [Thu] Perform weekly CVP content_set_check review
2023-05-17T16:08:56Z: INFO: found subtask ART-6495 - [Post Release Creation] Perform weekly security checks and updates
2023-05-17T16:08:56Z: INFO: found subtask ART-6496 - [Fri/Mon] QE moves advisories to REL_PREP
2023-05-17T16:08:57Z: INFO: found subtask ART-6497 - [Mon] [Once REL_PREP] ART provides non-golang container-first sources and operator-sdk
2023-05-17T16:08:58Z: INFO: found subtask ART-6499 - [Mon-Wed] EXD CLOUDDST pushes advisory content to production CDN
2023-05-17T16:08:59Z: INFO: found subtask ART-6500 - [Mon-Wed] EXD CLOUDDST pushes release content to customer portal
2023-05-17T16:08:59Z: INFO: found subtask ART-6501 - [Mon-Wed] QE notifies ON_QA bugzilla owners and analyze ci failures
2023-05-17T16:09:00Z: INFO: changed assignee of ART-6492 to huirwang@redhat.com
2023-05-17T16:09:04Z: INFO: changed assignee of ART-6496 to huirwang@redhat.com
2023-05-17T16:09:05Z: INFO: changed assignee of ART-6501 to huirwang@redhat.com
2023-05-17T16:10:05Z: WARNING: advisory state is not QE, it is SHIPPED_LIVE
2023-05-17T16:10:17Z: INFO: qe email of advisory 112393 is updated to huirwang@redhat.com
2023-05-17T16:10:17Z: WARNING: advisory state is not QE, it is SHIPPED_LIVE
2023-05-17T16:10:38Z: INFO: qe email of advisory 112392 is updated to huirwang@redhat.com
2023-05-17T16:10:38Z: WARNING: advisory state is not QE, it is SHIPPED_LIVE
2023-05-17T16:10:48Z: INFO: qe email of advisory 112394 is updated to huirwang@redhat.com
2023-05-17T16:10:48Z: WARNING: advisory state is not QE, it is SHIPPED_LIVE
2023-05-17T16:11:01Z: INFO: qe email of advisory 112391 is updated to huirwang@redhat.com
2023-05-17T16:11:01Z: WARNING: advisory state is not QE, it is SHIPPED_LIVE
2023-05-17T16:11:10Z: INFO: qe email of advisory 112395 is updated to huirwang@redhat.com
2023-05-17T16:11:12Z: INFO: task [Take ownership of advisories] status is changed to [Pass]
```