### PR TITLE
add cmd drop_bugs implementation

### DIFF
--- a/oar/cli/cmd_drop_bugs.py
+++ b/oar/cli/cmd_drop_bugs.py
@@ -1,0 +1,38 @@
+import click
+import logging
+from oar.core.worksheet_mgr import WorksheetManager
+from oar.core.advisory_mgr import AdvisoryManager
+from oar.core.config_store import ConfigStore
+from oar.core.const import *
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.pass_context
+def drop_bugs(ctx):
+    """
+    Drop bugs from advisories
+    """
+    # get config store from context
+    cs = ctx.obj["cs"]
+    try:
+        # get existing report
+        report = WorksheetManager(cs).get_test_report()
+        # init advisory manager
+        am = AdvisoryManager(cs)
+        # update task status to in progress
+        report.update_task_status(LABEL_TASK_DROP_BUGS, TASK_STATUS_INPROGRESS)
+        # check the greenwave test results for all advisories
+        bug_list = am.drop_bugs()
+        # check if all bugs are verified
+        if len(bug_list):
+            logger.info("updating test report")
+            report.update_bug_list(am.get_jira_issues())
+            # TODO: send slack message for dropped bugs
+            pass
+        report.update_task_status(LABEL_TASK_DROP_BUGS, TASK_STATUS_PASS)
+    except Exception as e:
+        logger.exception("Drop bugs from advisories failed")
+        report.update_task_status(LABEL_TASK_DROP_BUGS, TASK_STATUS_FAIL)
+        raise

--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -8,6 +8,7 @@ from oar.cli.cmd_take_ownership import take_ownership
 from oar.cli.cmd_update_bug_list import update_bug_list
 from oar.cli.cmd_check_greenwave_cvp_tests import check_greenwave_cvp_tests
 from oar.cli.cmd_push_to_cdn import push_to_cdn_staging
+from oar.cli.cmd_drop_bugs import drop_bugs
 from oar.cli.cmd_change_advisory_status import change_advisory_status
 from oar.core.config_store import ConfigStore, ConfigStoreException
 from oar.core.const import CONTEXT_SETTINGS
@@ -52,3 +53,4 @@ cli.add_command(update_bug_list)
 cli.add_command(check_greenwave_cvp_tests)
 cli.add_command(push_to_cdn_staging)
 cli.add_command(change_advisory_status)
+cli.add_command(drop_bugs)

--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -200,7 +200,7 @@ class AdvisoryManager:
 
                 if len(bug_list):
                     all_dropped_bugs += bug_list
-                    # ad.remove_bugs(bug_list)
+                    ad.remove_bugs(bug_list)
                     logger.info(
                         f"not verified and non-critical bugs are dropped from advisory {ad.errata_id}"
                     )

--- a/oar/core/worksheet_mgr.py
+++ b/oar/core/worksheet_mgr.py
@@ -333,6 +333,9 @@ class TestReport:
                     logger.info(
                         f"status of bug {issue.get_key()} is updated to {issue.get_status()}"
                     )
+                elif bug_key not in jira_issues:
+                    self._ws.update_acell("E" + str(row_idx), "Dropped")
+                    logger.info(f"bug {bug_key} is dropped")
                 else:
                     logger.info(f"bug status of {bug_key} is not changed")
             except Exception as e:

--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -32,3 +32,7 @@ class TestAdvisoryManager(unittest.TestCase):
     @unittest.skip("disable this case by default")
     def test_change_ad_status(self):
         self.am.change_advisory_status("REL_PREP")
+
+    @unittest.skip("disable this case by default")
+    def test_drop_bugs(self):
+        self.am.drop_bugs()


### PR DESCRIPTION
- add command `drop-bugs`
- command help
```
oar -r 4.12.19 drop-bugs -h
Usage: oar drop-bugs [OPTIONS]

  Drop bugs from advisories

Options:
  -h, --help  Show this message and exit.
```
- command output
```
oar -r 4.12.19 drop-bugs
2023-05-31T12:35:03Z: INFO: task [Remove unverified ON_QA bugs] status is changed to [In Progress]
2023-05-31T12:35:59Z: INFO: there is no bug in advisory 114720 can be dropped
2023-05-31T12:36:13Z: INFO: there is no bug in advisory 114719 can be dropped
2023-05-31T12:36:14Z: INFO: there is no bug in advisory 114721 can be dropped
2023-05-31T12:36:15Z: INFO: there is no bug in advisory 114718 can be dropped
2023-05-31T12:36:16Z: INFO: there is no bug in advisory 114722 can be dropped
2023-05-31T12:36:17Z: INFO: task [Remove unverified ON_QA bugs] status is changed to [Pass]
```