### PR TITLE
add notification support for cmd take-ownership

### DIFF
--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -56,16 +56,26 @@ class AdvisoryManager:
         Change QA owner of all the advisories
 
         Raises:
-            AdvisoryException: _description_
+            AdvisoryException: error when communicate with errata tool
+
+        Returns:
+            updated_ads ([]): updated advisory id list
+            abnormal_ads ([]): advisory id list of the ones state are not QE
         """
+        updated_ads = []
+        abnormal_ads = []
         try:
             for ad in self.get_advisories():
                 # check advisory status, if it is not QE, log warn message
                 if ad.errata_state != "QE":
                     logger.warn(f"advisory state is not QE, it is {ad.errata_state}")
+                    abnormal_ads.append(ad.errata_id)
                 ad.change_qe_email(self._cs.get_owner())
+                updated_ads.append(ad.errata_id)
         except ErrataException as e:
             raise AdvisoryException("change advisory owner failed") from e
+
+        return updated_ads, abnormal_ads
 
     def check_greenwave_cvp_tests(self):
         """

--- a/oar/core/config_store.json
+++ b/oar/core/config_store.json
@@ -14,7 +14,7 @@
         "slack": {
             "art": {
                 "channel": "#forum-release",
-                "id": "release-artist"
+                "id": "release-artists"
             },
             "qe": {
                 "channel": "#release-tests",

--- a/oar/core/jira_mgr.py
+++ b/oar/core/jira_mgr.py
@@ -143,16 +143,23 @@ class JiraManager:
     def change_assignee_of_qe_subtasks(self):
         """
         Change assignee of all QE subtasks from ART ticket
+
+        Returns:
+            updated_tasks([]): jira keys of updated subtasks
         """
+        updated_tasks = []
         subtasks = self.get_sub_tasks(self._cs.get_jira_ticket())
         if len(subtasks):
             for st in subtasks:
                 if st.get_summary() in JIRA_QE_TASK_SUMMARIES:
                     self.assign_issue(st.get_key(), self._cs.get_owner())
+                    updated_tasks.append(st.get_key())
                     if st.get_summary().startswith(
                         "[Wed-Fri]"
                     ) or st.get_summary().startswith("[Mon-Wed]"):
                         self.transition_issue(st.get_key(), JIRA_STATUS_IN_PROGRESS)
+
+        return updated_tasks
 
     def close_qe_subtasks(self):
         """

--- a/oar/core/notification_mgr.py
+++ b/oar/core/notification_mgr.py
@@ -70,6 +70,13 @@ class NotificationManager:
             self.sc.post_message(
                 self.cs.get_slack_channel_from_contact("qe"), slack_msg
             )
+            if len(abnormal_ads):
+                slack_msg = self.mh.get_slack_message_for_abnormal_advisory(
+                    abnormal_ads
+                )
+                self.sc.post_message(
+                    self.cs.get_slack_channel_from_contact("art"), slack_msg
+                )
         except Exception as e:
             raise NotificationException("share ownership change result failed") from e
 
@@ -257,6 +264,27 @@ class MessageHelper:
         message += "Found some abnormal advisories that state is not QE\n"
         for ad in abnormal_ads:
             message += self._to_link(util.get_advisory_link(ad), ad) + " "
+
+        return message
+
+    def get_slack_message_for_abnormal_advisory(self, abnormal_ads):
+        """
+        manipulate slack message for abnormal advisories, raise this issue with ART team
+
+        Args:
+            abnormal_ads ([]): advisory list
+
+        Returns:
+            str: slack message
+        """
+        gid = self.sc.get_group_id_by_name(
+            self.cs.get_slack_user_group_from_contact("art")
+        )
+
+        message = f"Hello {gid}, Can you help to check following [{self.cs.release}] advisories, issue: state is not QE, thanks\n"
+        for ad in abnormal_ads:
+            message += self._to_link(util.get_advisory_link(ad), ad) + " "
+        message += "\n"
 
         return message
 

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -36,3 +36,11 @@ def init_logging(log_level=logging.INFO):
         if "requests" in k or "urllib3" in k or "gssapi" in k:
             logger = logging.getLogger(k)
             logger.setLevel(logging.WARNING)
+
+
+def get_jira_link(key):
+    return "%s/browse/%s" % ("https://issues.redhat.com", key)
+
+
+def get_advisory_link(advisory):
+    return "https://errata.devel.redhat.com/advisory/%s" % advisory

--- a/oar/core/worksheet_mgr.py
+++ b/oar/core/worksheet_mgr.py
@@ -2,6 +2,7 @@ import gspread
 import gspread_formatting
 import os
 import logging
+import oar.core.util as util
 from oar.core.exceptions import WorksheetException
 from oar.core.config_store import ConfigStore
 from oar.core.const import *
@@ -178,7 +179,7 @@ class TestReport:
         """
         self._ws.update_acell(
             LABEL_JIRA,
-            self._to_hyperlink(self._to_jira_link(jira), jira),
+            self._to_hyperlink(util.get_jira_link(jira), jira),
         )
 
     def get_jira_info(self):
@@ -284,7 +285,7 @@ class TestReport:
             if issue.is_on_qa():
                 logger.debug(f"jira issue {key} is ON_QA, updating")
                 row_vals = []
-                row_vals.append(self._to_hyperlink(self._to_jira_link(key), key))
+                row_vals.append(self._to_hyperlink(util.get_jira_link(key), key))
                 row_vals.append(issue.get_qa_contact())
                 row_vals.append(issue.get_status())
                 batch_vals.append(row_vals)
@@ -354,7 +355,7 @@ class TestReport:
                         logger.info(f"found new ON_QA bug {key}")
                         row_vals = []
                         row_vals.append(
-                            self._to_hyperlink(self._to_jira_link(key), key)
+                            self._to_hyperlink(util.get_jira_link(key), key)
                         )
                         row_vals.append(issue.get_qa_contact())
                         row_vals.append(issue.get_status())
@@ -401,6 +402,3 @@ class TestReport:
 
     def _to_hyperlink(self, link, label):
         return f'=HYPERLINK("{link}","{label}")'
-
-    def _to_jira_link(self, key):
-        return "%s/browse/%s" % (self._cs.get_jira_server(), key)


### PR DESCRIPTION
- add func `share_ownership_change_result` in message helper to manipulate message for ownership change
- return `updated_ads`,`updated_subtasks`,`abormal_ads` from advisory and jira manager
- call func `share_ownership_change_result` in cmd `take-ownership` to send out slack message

- command output
```
oar -r 4.13.2 take-ownership --email wewang@redhat.com
2023-06-02T13:20:15Z: INFO: task [Take ownership of advisories] status is changed to [In Progress]
2023-06-02T13:20:18Z: INFO: found subtask ART-6939 - release blocker indicator
2023-06-02T13:20:19Z: INFO: found subtask ART-6940 - [Wed] Prepare the release
2023-06-02T13:20:19Z: INFO: found subtask ART-6941 - [Wed-Fri] QE does release verification
2023-06-02T13:20:20Z: INFO: found subtask ART-6942 - [Wed] Promote the tested nightly to 4-stable in CI and sign
2023-06-02T13:20:20Z: INFO: found subtask ART-6943 - [Thu] Perform weekly CVP content_set_check review
2023-06-02T13:20:21Z: INFO: found subtask ART-6944 - [Post Release Creation] Perform weekly security checks and updates
2023-06-02T13:20:21Z: INFO: found subtask ART-6945 - [Fri/Mon] QE moves advisories to REL_PREP
2023-06-02T13:20:21Z: INFO: found subtask ART-6946 - [Mon] [Once REL_PREP] ART provides non-golang container-first sources and operator-sdk
2023-06-02T13:20:22Z: INFO: found subtask ART-6947 - [Mon-Wed] EXD CLOUDDST pushes advisory content to production CDN
2023-06-02T13:20:22Z: INFO: found subtask ART-6948 - [Mon-Wed] EXD CLOUDDST pushes release content to customer portal
2023-06-02T13:20:23Z: INFO: found subtask ART-6949 - [Mon-Wed] QE notifies ON_QA bugzilla owners and analyze ci failures
2023-06-02T13:20:23Z: INFO: updating jira issue ART-6941 assignee
2023-06-02T13:20:24Z: INFO: jira issue ART-6941 assignee is updated to wewang@redhat.com
2023-06-02T13:20:24Z: INFO: updating jira issue ART-6941 status ...
2023-06-02T13:20:26Z: INFO: jira issue ART-6941 is updated to In Progress
2023-06-02T13:20:26Z: INFO: updating jira issue ART-6945 assignee
2023-06-02T13:20:27Z: INFO: jira issue ART-6945 assignee is updated to wewang@redhat.com
2023-06-02T13:20:27Z: INFO: updating jira issue ART-6949 assignee
2023-06-02T13:20:28Z: INFO: jira issue ART-6949 assignee is updated to wewang@redhat.com
2023-06-02T13:20:28Z: INFO: updating jira issue ART-6949 status ...
2023-06-02T13:20:31Z: INFO: jira issue ART-6949 is updated to In Progress
2023-06-02T13:22:47Z: INFO: QA Owner of advisory 115076 is updated to wewang@redhat.com
2023-06-02T13:23:08Z: INFO: QA Owner of advisory 115075 is updated to wewang@redhat.com
2023-06-02T13:23:21Z: INFO: QA Owner of advisory 115077 is updated to wewang@redhat.com
2023-06-02T13:23:21Z: WARNING: advisory state is not QE, it is NEW_FILES
2023-06-02T13:23:51Z: INFO: QA Owner of advisory 115074 is updated to wewang@redhat.com
2023-06-02T13:23:51Z: WARNING: advisory state is not QE, it is NEW_FILES
2023-06-02T13:23:58Z: INFO: QA Owner of advisory 115078 is updated to wewang@redhat.com
2023-06-02T13:23:59Z: INFO: task [Take ownership of advisories] status is changed to [Pass]
2023-06-02T13:24:04Z: INFO: sent slack message to <#release-tests>
2023-06-02T13:24:07Z: INFO: sent slack message to <#forum-release>
```