### PR TITLE
add notification support for cmd update-bug-list

### DIFF
--- a/oar/cli/cmd_take_ownership.py
+++ b/oar/cli/cmd_take_ownership.py
@@ -39,12 +39,12 @@ def take_ownership(ctx, email):
         updated_subtasks = JiraManager(cs).change_assignee_of_qe_subtasks()
         # update owner of advisories which status is QE
         updated_ads, abnormal_ads = AdvisoryManager(cs).change_ad_owners()
-        # update task status to pass
-        report.update_task_status(LABEL_TASK_OWNERSHIP, TASK_STATUS_PASS)
         # send notification
         NotificationManager(cs).share_ownership_change_result(
             updated_ads, abnormal_ads, updated_subtasks, cs.get_owner()
         )
+        # update task status to pass
+        report.update_task_status(LABEL_TASK_OWNERSHIP, TASK_STATUS_PASS)
     except Exception as e:
         logger.exception("take ownership of advisory and jira subtasks failed")
         report.update_task_status(LABEL_TASK_OWNERSHIP, TASK_STATUS_FAIL)

--- a/oar/cli/cmd_update_bug_list.py
+++ b/oar/cli/cmd_update_bug_list.py
@@ -5,6 +5,7 @@ from oar.core.worksheet_mgr import WorksheetManager, WorksheetException
 from oar.core.jira_mgr import JiraManager, JiraException
 from oar.core.advisory_mgr import AdvisoryManager, AdvisoryException
 from oar.core.config_store import ConfigStore
+from oar.core.notification_mgr import NotificationManager
 from oar.core.const import *
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,10 @@ def update_bug_list(ctx):
         # update task status to in progress
         report.update_task_status(LABEL_TASK_BUGS_TO_VERIFY, TASK_STATUS_INPROGRESS)
         # refresh bug list
-        report.update_bug_list(AdvisoryManager(cs).get_jira_issues())
+        jira_issues = AdvisoryManager(cs).get_jira_issues()
+        report.update_bug_list(jira_issues)
+        # send notification
+        NotificationManager(cs).share_bugs_to_be_verified(jira_issues)
         # check if all bugs are verified
         if report.are_all_bugs_verified():
             report.update_task_status(LABEL_TASK_BUGS_TO_VERIFY, TASK_STATUS_PASS)


### PR DESCRIPTION
- add func `get_slack_message_for_bug_verification` in message helper to generate slack message
- send notification in cmd impl `update-bug-list`

- command output
```
oar -r 4.13.2 update-bug-list
2023-06-02T15:54:00Z: INFO: task [Bug to be verified] status is changed to [In Progress]
2023-06-02T15:55:03Z: INFO: found existing bug OCPBUGS-4388 in report, checking...
2023-06-02T15:55:03Z: INFO: bug status of OCPBUGS-4388 is not changed
2023-06-02T15:55:04Z: INFO: found existing bug OCPBUGS-646 in report, checking...
2023-06-02T15:55:05Z: INFO: bug status of OCPBUGS-646 is not changed
2023-06-02T15:55:06Z: INFO: found existing bug OCPBUGS-13480 in report, checking...
2023-06-02T15:55:06Z: INFO: bug status of OCPBUGS-13480 is not changed
2023-06-02T15:55:07Z: INFO: found existing bug OCPBUGS-13486 in report, checking...
2023-06-02T15:55:08Z: INFO: bug status of OCPBUGS-13486 is not changed
2023-06-02T15:55:09Z: INFO: found existing bug OCPBUGS-13277 in report, checking...
2023-06-02T15:55:09Z: INFO: bug status of OCPBUGS-13277 is not changed
2023-06-02T15:55:10Z: INFO: found existing bug OCPBUGS-13492 in report, checking...
2023-06-02T15:55:11Z: INFO: bug status of OCPBUGS-13492 is not changed
2023-06-02T15:55:44Z: WARNING: cannot get slack user id for <ddarrah+jira@redhat.com>: The request to the Slack API failed. (url: https://www.slack.com/api/users.lookupByEmail)
The server responded with: {'ok': False, 'error': 'users_not_found'}
2023-06-02T15:55:46Z: WARNING: cannot get slack user id for <ddarrah+jira@redhat.com>: The request to the Slack API failed. (url: https://www.slack.com/api/users.lookupByEmail)
The server responded with: {'ok': False, 'error': 'users_not_found'}
2023-06-02T15:55:48Z: INFO: sent slack message to <#release-tests>
2023-06-02T15:55:48Z: INFO: checking all bugs are verified
2023-06-02T15:55:49Z: INFO: result is: no
```