### PR TITLE
save result to /tmp folder

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -26,7 +26,7 @@ Commands:
   get_payloads  Check the latest payload of each version.
   get_results   Return the Prow job executed info.
   list          List the jobs which support the API call.
-  run           Run a job and save results to prow-jobs.csv
+  run           Run a job and save results to /tmp/prow-jobs.csv
   run_required  Run required jobs from a file
 ```
 

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -169,7 +169,7 @@ class Jobs(object):
 
     def save_job_data(self, dict):
          # save it to the crrent CSV file
-         with open('prow-jobs.csv', 'a', newline='', encoding='utf-8') as f:
+         with open('/tmp/prow-jobs.csv', 'a', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
             L = [dict['jobName'], dict['payload'], dict['upgrade_from'], dict['upgrade_to'], dict['time'], dict['jobID'], dict['jobURL']]
             writer.writerow(L)
@@ -404,7 +404,7 @@ def get_cmd(job_id):
 @click.option("--upgrade_from", help="specify an original payload for upgrade test.")
 @click.option("--upgrade_to", help="specify a target payload for upgrade test.")
 def run_cmd(job_name, payload, upgrade_from, upgrade_to):
-    """Run a job and save results to prow-jobs.csv"""
+    """Run a job and save results to /tmp/prow-jobs.csv"""
     job.run_job(job_name, payload, upgrade_from, upgrade_to)
 
 @cli.command("list")


### PR DESCRIPTION
Test
```console
MacBook-Pro:~ jianzhang$ job run periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-gcp-upi-private-xpn-ingress-glb-p2-f14 --payload  quay.io/openshift-release-dev/ocp-release:4.11.0-assembly.art6883.3
Debug mode is off
Returned job id: 8f0fa25f-4109-4e31-9102-a9cc945680f5
periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-gcp-upi-private-xpn-ingress-glb-p2-f14 quay.io/openshift-release-dev/ocp-release:4.11.0-assembly.art6883.3 8f0fa25f-4109-4e31-9102-a9cc945680f5 2023-06-07T08:11:34Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-gcp-upi-private-xpn-ingress-glb-p2-f14/1666357216782848000
MacBook-Pro:~ jianzhang$ 
MacBook-Pro:~ jianzhang$ cat /tmp/prow-jobs.csv 
periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-gcp-upi-private-xpn-ingress-glb-p2-f14,quay.io/openshift-release-dev/ocp-release:4.11.0-assembly.art6883.3,,,2023-06-07T08:11:34Z,8f0fa25f-4109-4e31-9102-a9cc945680f5,https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-gcp-upi-private-xpn-ingress-glb-p2-f14/1666357216782848000
```