### PR TITLE
add impl of cmd check-cve-tracker-bug

### DIFF
--- a/oar/cli/cmd_check_cve_tracker_bug.py
+++ b/oar/cli/cmd_check_cve_tracker_bug.py
@@ -1,0 +1,37 @@
+import click
+import logging
+from oar.core.worksheet_mgr import WorksheetManager
+from oar.core.advisory_mgr import AdvisoryManager
+from oar.core.config_store import ConfigStore
+from oar.core.notification_mgr import NotificationManager
+from oar.core.const import *
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.pass_context
+def check_cve_tracker_bug(ctx):
+    """
+    Check if there is any missed CVE tracker bug
+    """
+    # get config store from context
+    cs = ctx.obj["cs"]
+    try:
+        # get existing report
+        report = WorksheetManager(cs).get_test_report()
+        # init advisory manager
+        am = AdvisoryManager(cs)
+        # update task status to in progress
+        report.update_task_status(LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_INPROGRESS)
+        # trigger push job for cdn stage targets
+        cve_tracker_bugs = am.check_cve_tracker_bug()
+        if cve_tracker_bugs:
+            NotificationManager(cs).share_missed_cve_tracker_bugs(cve_tracker_bugs)
+        else:
+            logger.info("no new CVE tracker bug found")
+        report.update_task_status(LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_PASS)
+    except Exception as e:
+        logger.exception("check cve tracker bug failed")
+        report.update_task_status(LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_FAIL)
+        raise

--- a/oar/cli/cmd_check_cve_tracker_bug.py
+++ b/oar/cli/cmd_check_cve_tracker_bug.py
@@ -27,7 +27,7 @@ def check_cve_tracker_bug(ctx):
         # trigger push job for cdn stage targets
         cve_tracker_bugs = am.check_cve_tracker_bug()
         if cve_tracker_bugs:
-            NotificationManager(cs).share_missed_cve_tracker_bugs(cve_tracker_bugs)
+            NotificationManager(cs).share_new_cve_tracker_bugs(cve_tracker_bugs)
         else:
             logger.info("no new CVE tracker bug found")
         report.update_task_status(LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_PASS)

--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -10,6 +10,7 @@ from oar.cli.cmd_check_greenwave_cvp_tests import check_greenwave_cvp_tests
 from oar.cli.cmd_push_to_cdn import push_to_cdn_staging
 from oar.cli.cmd_drop_bugs import drop_bugs
 from oar.cli.cmd_change_advisory_status import change_advisory_status
+from oar.cli.cmd_check_cve_tracker_bug import check_cve_tracker_bug
 from oar.core.config_store import ConfigStore, ConfigStoreException
 from oar.core.const import CONTEXT_SETTINGS
 
@@ -54,3 +55,4 @@ cli.add_command(check_greenwave_cvp_tests)
 cli.add_command(push_to_cdn_staging)
 cli.add_command(change_advisory_status)
 cli.add_command(drop_bugs)
+cli.add_command(check_cve_tracker_bug)

--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -228,7 +228,7 @@ class AdvisoryManager:
 
     def check_cve_tracker_bug(self):
         """
-        Call elliott cmd to check if any CVE tracke bug is missed
+        Call elliott cmd to check if any new CVE tracke bug found
 
         Raises:
             AdvisoryException: error when invoke elliott cmd

--- a/oar/core/notification_mgr.py
+++ b/oar/core/notification_mgr.py
@@ -109,6 +109,25 @@ class NotificationManager:
         except Exception as e:
             raise NotificationException("share bugs to be verified failed") from e
 
+    def share_missed_cve_tracker_bugs(self, cve_tracker_bugs):
+        """
+        Send slack message to ART team with new CVE tracker bugs
+
+        Args:
+            cve_tracker_bugs ([]): list of new CVE tracker bug
+
+        Raises:
+            NotificationException: error when checking new CVE tracker bugs
+        """
+        try:
+            slack_msg = self.mh.get_slack_message_for_cve_tracker_bugs(cve_tracker_bugs)
+            if len(slack_msg):
+                self.sc.post_message(
+                    self.cs.get_slack_channel_from_contact("art"), slack_msg
+                )
+        except Exception as e:
+            raise NotificationException("share missed CVE tracker bugs failed") from e
+
 
 class MailClient:
     """
@@ -338,6 +357,27 @@ class MessageHelper:
         message = f"Hello {gid}, Can you help to check following [{self.cs.release}] advisories, issue: state is not QE, thanks\n"
         for ad in abnormal_ads:
             message += self._to_link(util.get_advisory_link(ad), ad) + " "
+        message += "\n"
+
+        return message
+
+    def get_slack_message_for_cve_tracker_bugs(self, cve_tracker_bugs):
+        """
+        manipulate slack message for new CVE tracker bugs
+
+        Args:
+            cve_tracker_bugs ([]): list of new CVE tracker bug
+
+        Returns:
+            str: slack message
+        """
+        gid = self.sc.get_group_id_by_name(
+            self.cs.get_slack_user_group_from_contact("art")
+        )
+
+        message = f"Hello {gid}, Found new CVE tracker bugs not attached on advisories, could you take a look, thanks\n"
+        for bug in cve_tracker_bugs:
+            message += self._to_link(util.get_jira_link(bug), bug) + " "
         message += "\n"
 
         return message

--- a/oar/core/notification_mgr.py
+++ b/oar/core/notification_mgr.py
@@ -109,7 +109,7 @@ class NotificationManager:
         except Exception as e:
             raise NotificationException("share bugs to be verified failed") from e
 
-    def share_missed_cve_tracker_bugs(self, cve_tracker_bugs):
+    def share_new_cve_tracker_bugs(self, cve_tracker_bugs):
         """
         Send slack message to ART team with new CVE tracker bugs
 

--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -36,3 +36,7 @@ class TestAdvisoryManager(unittest.TestCase):
     @unittest.skip("disable this case by default")
     def test_drop_bugs(self):
         self.am.drop_bugs()
+
+    def test_check_cve_tracker_bug(self):
+        tracker_bugs = self.am.check_cve_tracker_bug()
+        self.assertFalse(tracker_bugs)


### PR DESCRIPTION
- call `elliott` cmd to check if there is any new cve tracker bug found
- send slack notification to art team if new tracker bug found

- command help
```
oar -r 4.12.11 check-cve-tracker-bug -h
Usage: oar check-cve-tracker-bug [OPTIONS]

  Check if there is any missed CVE tracker bug

Options:
  -h, --help  Show this message and exit.
```
- command output
```
oar -r 4.13.2 check-cve-tracker-bug
2023-06-08T13:37:57Z: INFO: task [Check CVE tracker bugs] status is changed to [In Progress]
2023-06-08T13:39:06Z: INFO: found not attached CVE tracker bug
2023-06-08T13:39:06Z: INFO: OCPBUGS-13486: CVE-2023-24540 skopeo: golang: html/template: improper handl
2023-06-08T13:39:06Z: INFO: OCPBUGS-13480: CVE-2023-24540 podman: golang: html/template: improper handl
2023-06-08T13:39:06Z: INFO: OCPBUGS-13474: CVE-2023-24540 openshift-clients: golang: html/template: imp
2023-06-08T13:39:06Z: INFO: OCPBUGS-13468: CVE-2023-24540 openshift: golang: html/template: improper ha
2023-06-08T13:39:06Z: INFO: OCPBUGS-13438: CVE-2023-24540 buildah: golang: html/template: improper hand
2023-06-08T13:39:15Z: INFO: sent slack message to <#release-tests>


oar -r 4.12.11 check-cve-tracker-bug
2023-06-08T14:03:29Z: INFO: task [Check CVE tracker bugs] status is changed to [In Progress]
2023-06-08T14:04:35Z: INFO: no new CVE tracker bug found
2023-06-08T14:04:36Z: INFO: task [Check CVE tracker bugs] status is changed to [Pass]
```
this command can run multiple times during z-stream release cycle