### PR TITLE
avoid jenkins util error info

### DIFF
--- a/oar/cli/cmd_stage_testing.py
+++ b/oar/cli/cmd_stage_testing.py
@@ -20,7 +20,7 @@ def stage_testing(ctx, build_number):
     cs = ctx.obj["cs"] 
     jh = JenkinsHelper(cs) 
     if not build_number:
-        logger.warn("job id is not set, will trigger stage testing")
+        logger.info("job id is not set, will trigger stage testing")
         try:
             report = WorksheetManager(cs).get_test_report()
             stage_test_result = report.get_task_status(LABEL_TASK_STAGE_TEST)
@@ -36,7 +36,7 @@ def stage_testing(ctx, build_number):
                         logger.exception("trigger stage pipeline job failed")
                         raise
                     logger.info(f"triggerred stage pipeline job: <{build_url}>")
-                    nm.sc.post_message(cs.get_slack_channel_from_contact("qe"), "<"+cs.release+"> stage testing job: "+build_url)
+                    nm.sc.post_message(cs.get_slack_channel_from_contact("qe"), "["+cs.release+"] stage testing job: "+build_url)
                     report.update_task_status(LABEL_TASK_STAGE_TEST, TASK_STATUS_INPROGRESS)
                 else:
                     logger.info("push to cdn stage is not completed, so will not trigger stage test")

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -36,7 +36,9 @@ def init_logging(log_level=logging.INFO):
         if "requests" in k or "urllib3" in k or "gssapi" in k:
             logger = logging.getLogger(k)
             logger.setLevel(logging.WARNING)
-
+        if "requests_kerberos" in k:
+            logger = logging.getLogger(k)
+            logger.setLevel(logging.CRITICAL)
 
 def get_jira_link(key):
     return "%s/browse/%s" % ("https://issues.redhat.com", key)


### PR DESCRIPTION
about "ERROR: handle_other(): Mutual authentication failed", it's python jenkins related bug, the bug is still new: [bugs.launchpad.net/python-jenkins/+bug/1849302](https://bugs.launchpad.net/python-jenkins/+bug/1849302), it just give the error info, not affect connect to jenkins.
but we avoid display the info.
[wewang@ovpn-12-28 release-tests]$ python cli -r 4.13.2 stage-testing
2023-06-15T15:21:51Z: INFO: job id is not set, will trigger stage testing
2023-06-15T15:22:00Z: INFO: triggerred stage pipeline job: <https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/zstreams/job/Stage-Pipeline/740>
2023-06-15T15:22:01Z: INFO: sent slack message to <#release-tests>
2023-06-15T15:22:03Z: INFO: task [Stage testing] status is changed to [In Progress]
@rioliu-rh  please review it, thanks