### PR TITLE
fix 409 conflict and update jobs

### DIFF
--- a/_releases/required-jobs.json
+++ b/_releases/required-jobs.json
@@ -1,71 +1,41 @@
 { 
-    "4.11" : {
-        "amd64" : {
-            "jobs" : [
-                "aws-c2s-ipi-disconnected-private-p2-f14",
-                "azure-ipi-disconnected-fullyprivate-p2-f14",
-                "gcp-ipi-proxy-private-p2-f14",
-                "vsphere-ipi-proxy-fips-p2-f14"
-                    ]
-        },
-        "arm64" : {
-            "jobs" : [
-                "aws-ipi-disconnected-cco-manual-sts-ep-p2-f28",
-                "aws-ipi-ovn-fips-p2-f28",
-                "aws-ipi-proxy-cco-manual-sts-p2-f28"
-            ]
-        }
-    },
-    "4.12" : {
-        "amd64" : {
-            "jobs" : [
-                "aws-ipi-proxy-cco-manual-sts-p2-f14", 
-                "azure-ipi-proxy-workers-rhcos-rhel8-p2-f7",
-                "vsphere-ipi-proxy-workers-rhel8-p2-f14", 
-                "gcp-ipi-ovn-p2-f7",
-                "gcp-ipi-ovn-ipsec-p2-f14",
-                "nutanix-ipi-fips-p2-f14",
-                "aws-c2s-ipi-disconnected-private-p2-f14",
-                "azure-ipi-fips-p2-f30",
-                "aws-rosa-sts-hypershift-guest-integration-critical-p1-f2",
-                "azure-ipi-disconnected-fullyprivate-p2-f28"
-                    ]
-        },
-        "arm64" : {
-            "jobs" : [
-                "aws-ipi-p2-f14",
-                "aws-ipi-disconnected-cco-manual-sts-ep-p2-f28",
-                "aws-ipi-ovn-fips-p2-f28",
-                "aws-ipi-proxy-cco-manual-sts-p2-f28",
-                "aws-ipi-disconnected-cco-manual-sts-ep-p2-f28",
-                "aws-ipi-ovn-fips-p2-f28"
-            ]
-        }
-    },
-    "4.13" : {
-        "amd64" : {
-            "jobs" : [
-                "aws-ipi-disconnected-cco-manual-sts-ep",
-                "aws-c2s-ipi-disconnected-private",
-                "aws-ipi-ovn-fips",
-                "vsphere-ipi-proxy-fips",
-                "nutanix-ipi-proxy-fips",
-                "ibmcloud-ipi-private-fips",
-                "gcp-ipi-proxy-private",
-                "azure-ipi-fullyprivate-proxy",
-                "azure-ipi-fips",
-                "azure-ipi-baselinecaps-v412-to-multiarch",
-                "aws-rosa-sts"
-                    ]
-        },
-        "arm64" : {
-            "jobs" : [
-                "aws-ipi-disconnected-cco-manual-sts-ep",
-                "azure-ipi-disconnected-fullyprivate",
-                "azure-ipi-fips",
-                "aws-ipi-ovn-ipsec-to-multiarch",
-                "baremetal-upi-to-multiarch"
-            ]
-        }
-    }
+    "4.10" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28"
+    ],
+    "4.11" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-aws-c2s-ipi-disconnected-private-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-azure-ipi-disconnected-fullyprivate-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-gcp-ipi-proxy-private-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-vsphere-ipi-proxy-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-arm64-stable-aws-ipi-ovn-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.10-aws-ipi-ovn-ingress-nlb-fips-p2-f14"
+    ],
+    "4.12" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-ipi-ovn-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-vsphere-ipi-proxy-workers-rhel8-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-4.12-upgrade-from-stable-4.11-gcp-ipi-ovn-ipsec-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-nutanix-ipi-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-rosa-sts-hypershift-guest-integration-critical-p1-f2",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-azure-ipi-disconnected-fullyprivate-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-multi-nightly-aws-ipi-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-aws-ipi-ovn-fips-p2-f28"
+    ],
+    "4.13" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-ovn-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-vsphere-ipi-proxy-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-nutanix-ipi-proxy-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-ibmcloud-ipi-private-fips-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-4.13-upgrade-from-stable-4.12-gcp-ipi-proxy-private-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-4.13-upgrade-from-stable-4.12-azure-ipi-fullyprivate-proxy-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-azure-ipi-baselinecaps-v412-to-multiarch-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-aws-rosa-sts-p2-f7",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-nightly-azure-ipi-disconnected-fullyprivate-tp-p3-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-aws-ipi-ovn-ipsec-to-multiarch-p2-f14",
+        " periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-baremetal-upi-to-multiarch-p2-f7"
+    ]
 }

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -99,7 +99,7 @@ class Jobs(object):
             if VersionInfo.parse(oldVersion) < VersionInfo.parse(content): 
                 sha = self.get_sha(url)
                 # sha is Required if you are updating a file.
-                data = {"sha": sha,"content": base64Content,"branch": "master", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
+                data = {"sha": sha,"content": base64Content,"branch": "record", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
                 self.push_action(url, data)
                 if run:
                     default_file= "_releases/required-jobs.json"
@@ -109,7 +109,7 @@ class Jobs(object):
                 print("No update! since the recored version %s >= the new version %s" % (oldVersion, content))
         elif res.status_code == 404:
             print("file %s doesn't exist, create it." % url)
-            data = {"content":base64Content,"branch": "master", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
+            data = {"content":base64Content,"branch": "record", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
             self.push_action(url, data)
             if run:
                 default_file= "_releases/required-jobs.json"
@@ -206,16 +206,12 @@ class Jobs(object):
                 print(channel)
                 exist_jobs = self.search_job(None, channel)
                 if channel in job_dict.keys():
-                    if 'amd64' in job_dict[channel].keys():
-                        for job in job_dict[channel]['amd64']['jobs']:
-                            for j in exist_jobs['periodics']:
-                                if job in j['name'] and type in j['name']:
-                                    self.run_job(j['name'], None, None, None)
-                    if 'arm64' in job_dict[channel].keys():
-                        for job in job_dict[channel]['arm64']['jobs']:
-                            for j in exist_jobs['periodics']:
-                                if job in j['name'] and type in j['name']:
-                                    self.run_job(j['name'], None, None, None)
+                    print(channel)
+                    for job in job_dict[channel]:
+                        print(job)
+                        for j in exist_jobs['periodics']:
+                            if job in j['name'] and type in j['name']:
+                                self.run_job(j['name'], None, None, None)
 
     # run_job func runs job by calling the API
     def run_job(self, jobName, payload, upgrade_from, upgrade_to):


### PR DESCRIPTION
- Use the `record` branch instead of the `master` branch since the `master` branch is a protection branch.

```console
getting the latest payload of 4.12.0
The latest version of 4.12 is: 4.12.22
file https://api.github.com/repos/openshift/release-tests/contents/_releases/Auto-OCP-4.12.txt doesn't exist, create it.
409 Conflict
use file: _releases/required-jobs.json
```

- Update jobs