### PR TITLE
use the record branch instead of master

### DIFF
--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -88,8 +88,7 @@ class Jobs(object):
             print(res.status_code, res.reason)
 
     def push_versions(self, content, file, run):
-        # file = ".auto-OCP-4.12.txt"
-        url = "https://api.github.com/repos/openshift/release-tests/contents/_releases/" + file
+        url = "https://api.github.com/repos/openshift/release-tests/contents/_releases/{}?ref=record".format(file)
         base64Content = base64.b64encode(bytes(content, encoding='utf-8')).decode('utf-8')
         # print(base64Content)
         # check if the file exist


### PR DESCRIPTION
Fix the below issue
```console
The latest version of 4.11 is: 4.11.44
file https://api.github.com/repos/openshift/release-tests/contents/_releases/Auto-OCP-4.11.txt doesn't exist, create it.
422 Unprocessable Entity
use file: _releases/required-jobs.json
4.11.
```