### PR TITLE
update jobs

### DIFF
--- a/_releases/required-jobs.json
+++ b/_releases/required-jobs.json
@@ -4,7 +4,10 @@
         "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28",
-        "periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28"
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-4.10-upgrade-from-eus-4.8-aws-ipi-ovn-p2-f30",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.9-aws-ipi-byo-kms-etcd-encryption-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.10-azure-ipi-fips-p2-f1"
     ],
     "4.11" : [
         "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-aws-c2s-ipi-disconnected-private-fips-p2-f14",
@@ -12,30 +15,43 @@
         "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-gcp-ipi-proxy-private-p2-f14",
         "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-vsphere-ipi-proxy-fips-p2-f14",
         "periodic-ci-openshift-openshift-tests-private-release-4.11-arm64-stable-aws-ipi-ovn-p2-f28",
-        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.10-aws-ipi-ovn-ingress-nlb-fips-p2-f14"
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.10-azure-ipi-workers-rhel8-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.11-vsphere-ipi-proxy-fips-p2-f360"
     ],
     "4.12" : [
         "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-ipi-ovn-fips-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-vsphere-ipi-proxy-workers-rhel8-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-4.12-upgrade-from-stable-4.11-gcp-ipi-ovn-ipsec-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-nutanix-ipi-fips-p2-f14",
         "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-rosa-sts-hypershift-guest-integration-critical-p1-f2",
         "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-azure-ipi-disconnected-fullyprivate-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.12-multi-nightly-aws-ipi-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-aws-ipi-ovn-fips-p2-f28"
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-aws-ipi-ovn-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-4.12-upgrade-from-stable-4.12-vsphere-upi-p3-f28"
     ],
     "4.13" : [
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-ovn-fips-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-vsphere-ipi-proxy-fips-p2-f14",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-nutanix-ipi-proxy-fips-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-ibmcloud-ipi-private-fips-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-4.13-upgrade-from-stable-4.12-gcp-ipi-proxy-private-p2-f14",
-        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-4.13-upgrade-from-stable-4.12-azure-ipi-fullyprivate-proxy-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-azure-ipi-baselinecaps-v412-to-multiarch-p2-f14",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-aws-rosa-sts-p2-f7",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-nightly-azure-ipi-disconnected-fullyprivate-tp-p3-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-aws-ipi-ovn-ipsec-to-multiarch-p2-f14",
-        " periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-baremetal-upi-to-multiarch-p2-f7"
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-baremetal-upi-to-multiarch-p2-f7",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-4.13-upgrade-from-stable-4.12-gcp-ipi-proxy-private-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-4.13-upgrade-from-stable-4.12-azure-ipi-fullyprivate-proxy-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-ovn-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-byo-iam-role-cert-rotation-p2-f14"
+    ],
+    "4.14" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-vsphere-upi-zones-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-nutanix-ipi-image-registry-s3-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-ibmcloud-ipi-workers-rhel8-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-gcp-upi-xpn-p2-f14",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-baremetalds-ipi-ovn-ipv4-fips-p1-f4",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-azure-stack-upi-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-aws-upi-p3-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-alibaba-ipi-private-fips-p3-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-azure-ipi-ingress-custom-controller-fips-p2-f28",
+        "periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-vsphere-ipi-sdn-p2-f28"
     ]
 }


### PR DESCRIPTION
Log:
```console
MacBook-Pro:release-tests jianzhang$ job run_required --channel 4.10 --file _releases/required-jobs.json --version 4.10.63
Debug mode is off
use file: _releases/required-jobs.json
Hanling 4.10
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28
Returned job id: 7fae954c-312e-47a3-a0fb-2bade0ced453
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28 quay.io/openshift-release-dev/ocp-release:4.10.63-x86_64 7fae954c-312e-47a3-a0fb-2bade0ced453 2023-06-30T09:45:25Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28/1674715754919890944
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28
Returned job id: 602b5eca-4db9-4205-8c77-a200f5a89e82
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28 quay.io/openshift-release-dev/ocp-release:4.10.63-x86_64 602b5eca-4db9-4205-8c77-a200f5a89e82 2023-06-30T09:45:27Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28/1674715762935205888
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28
Returned job id: fd842cf9-2b7a-4f3a-a17c-c30eb83a0231
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28 quay.io/openshift-release-dev/ocp-release:4.10.63-x86_64 fd842cf9-2b7a-4f3a-a17c-c30eb83a0231 2023-06-30T09:45:28Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28/1674715770082299904
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28
Returned job id: c6114231-de83-4c40-acf5-2a85cb5446fa
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28 quay.io/openshift-release-dev/ocp-release:4.10.63-x86_64 c6114231-de83-4c40-acf5-2a85cb5446fa 2023-06-30T09:45:30Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28/1674715777132924928
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28
Returned job id: 842a14c0-4946-4cd4-95d4-6d92dbc661c9
periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28 quay.io/openshift-release-dev/ocp-release:4.10.63-aarch64 842a14c0-4946-4cd4-95d4-6d92dbc661c9 2023-06-30T09:45:32Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28/1674715784372293632
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-4.10-upgrade-from-eus-4.8-aws-ipi-ovn-p2-f30
Returned job id: f2499672-8bf9-4d02-9c76-3c70a0591ad0
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-4.10-upgrade-from-eus-4.8-aws-ipi-ovn-p2-f30 None f2499672-8bf9-4d02-9c76-3c70a0591ad0 2023-06-30T09:45:34Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-4.10-upgrade-from-eus-4.8-aws-ipi-ovn-p2-f30/1674715791506804736
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.9-aws-ipi-byo-kms-etcd-encryption-p2-f14
Returned job id: 289863f7-7ae8-4d8e-89a9-91ed271d5a89
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.9-aws-ipi-byo-kms-etcd-encryption-p2-f14 None 289863f7-7ae8-4d8e-89a9-91ed271d5a89 2023-06-30T09:45:35Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.9-aws-ipi-byo-kms-etcd-encryption-p2-f14/1674715798595178496
Done.
Hanling periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.10-azure-ipi-fips-p2-f1
Returned job id: 9e60aa8c-8158-4a63-a1bc-39874bce3a6b
periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.10-azure-ipi-fips-p2-f1 None 9e60aa8c-8158-4a63-a1bc-39874bce3a6b 2023-06-30T09:45:37Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.10-azure-ipi-fips-p2-f1/1674715805746466816
Done.
```