### PR TITLE
Fix issues for ARM

### DIFF
--- a/prow/job/__init__.py
+++ b/prow/job/__init__.py
@@ -1,2 +1,2 @@
-version_info = (1, 0, 8)
+version_info = (2, 0, 0)
 version = '.'.join(str(c) for c in version_info)


### PR DESCRIPTION
There are 4 Envs for OCP payload, 
```console
"RELEASE_IMAGE_LATEST"
"RELEASE_IMAGE_TARGET"
"RELEASE_IMAGE_ARM64_LATEST"
"RELEASE_IMAGE_ARM64_TARGET"
```
But, for ARM jobs, we have to set the `RELEASE_IMAGE_LATEST`(x86) when using the API call since it contains the `cli` image. Otherwise, you will get the error below, such as https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.12-arm64-stable-baremetalds-ipi-ovn-ipv4-p2-f14/1675773761678217216 
A DPTP issue: https://issues.redhat.com/browse/DPTP-3538
```console
ERRO[2023-07-03T07:51:10Z] 
  * could not run steps: step [release:latest] failed: failed to get CLI image: unable to find the 'cli' image in the provided release image: could not watch pod: the pod ci-op-8f84pvi4/release-images-latest-cli failed after 8s (failed containers: release): ContainerFailed one or more containers exited
  ```