### PR TITLE
add http level debug logging

### DIFF
--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#coding:utf-8
+# coding:utf-8
 import requests
 import time
 import json
@@ -11,31 +11,36 @@ import sys
 import re
 import csv
 import click
+import logging
+import http.client as httpclient
+
 
 class Jobs(object):
     def __init__(self):
-        self.url = 'https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags'
+        self.url = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
         # config the based URL here
-        self.jobURL='https://api.github.com/repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/{}?ref=master'
-        self.gangwayURL = "https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions/"
+        self.jobURL = "https://api.github.com/repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/{}?ref=master"
+        self.gangwayURL = (
+            "https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions/"
+        )
         self.prowJobURL = "https://prow.ci.openshift.org/prowjob?prowjob={}"
 
     # get_prow_headers func adds the Prow Token
     def get_prow_headers(self):
-        token = os.getenv('APITOKEN')
+        token = os.getenv("APITOKEN")
         if token:
-            headers = {'Authorization': 'Bearer ' + token.strip()}
+            headers = {"Authorization": "Bearer " + token.strip()}
             return headers
         else:
-            print('No Prow API token found, exit...')
+            print("No Prow API token found, exit...")
             sys.exit(0)
 
     def get_job_data(self, payload, upgrade_from, upgrade_to):
-        data = {'job_execution_type': '1'}
+        data = {"job_execution_type": "1"}
         if payload is not None and upgrade_from is not None and upgrade_to is not None:
             print("Error! You cannot run e2e and upgrade test at the same time!")
             sys.exit(1)
-        # amd_latest env is must no mater what platforms you run 
+        # amd_latest env is must no mater what platforms you run
         amd_latest = "RELEASE_IMAGE_LATEST"
         amd_target = "RELEASE_IMAGE_TARGET"
         arm_latest = "RELEASE_IMAGE_ARM64_LATEST"
@@ -44,79 +49,41 @@ class Jobs(object):
         # so hard code a x86 image here, see bug: https://issues.redhat.com/browse/DPTP-3538
         base_image = "quay.io/openshift-release-dev/ocp-release:4.13.4-x86_64"
         if payload is not None:
-            env = {"envs":  
-                     { 
-                         amd_latest: payload
-                    }
-            } 
+            env = {"envs": {amd_latest: payload}}
             if "arm64" in payload or "aarch64" in payload:
-                env = {"envs":  
-                     { 
-                        amd_latest: base_image,
-                        arm_latest: payload
-                    }
-                } 
-        
+                env = {"envs": {amd_latest: base_image, arm_latest: payload}}
+
         if upgrade_from is not None and upgrade_to is not None:
             # x86 as default
-            env = { "envs":  
-                    { 
-                    amd_latest: upgrade_from,
-                    amd_target: upgrade_to
-                }
-            } 
-            # check if it's for ARM, and amd_latest env is must no mater what platforms you run           
+            env = {"envs": {amd_latest: upgrade_from, amd_target: upgrade_to}}
+            # check if it's for ARM, and amd_latest env is must no mater what platforms you run
             if "arm64" in upgrade_from or "aarch64" in upgrade_from:
-                env = {"envs":  
-                     { amd_latest: base_image,
-                       arm_latest: upgrade_from
-                    }
-                } 
+                env = {"envs": {amd_latest: base_image, arm_latest: upgrade_from}}
             if "arm64" in upgrade_to or "aarch64" in upgrade_to:
-                env = {"envs":  
-                     { amd_latest: base_image,
-                       arm_target: upgrade_to
-                    }
-                }
-            if ("arm64" in upgrade_from or "aarch64" in upgrade_from) and ("arm64" in upgrade_to or "aarch64" in upgrade_to):
-                env = {"envs":  
-                     { amd_latest: base_image,
-                       arm_latest: upgrade_from,
-                       arm_target: upgrade_to
+                env = {"envs": {amd_latest: base_image, arm_target: upgrade_to}}
+            if ("arm64" in upgrade_from or "aarch64" in upgrade_from) and (
+                "arm64" in upgrade_to or "aarch64" in upgrade_to
+            ):
+                env = {
+                    "envs": {
+                        amd_latest: base_image,
+                        arm_latest: upgrade_from,
+                        arm_target: upgrade_to,
                     }
                 }
         if upgrade_from is None and upgrade_to is not None:
-            env = { "envs":  
-                    { 
-                    amd_target: upgrade_to
-                }
-            } 
+            env = {"envs": {amd_target: upgrade_to}}
             if "arm64" in upgrade_to or "aarch64" in upgrade_to:
-                env = {"envs":  
-                     { amd_latest: base_image,
-                       arm_target: upgrade_to
-                    }
-                }
+                env = {"envs": {amd_latest: base_image, arm_target: upgrade_to}}
         if upgrade_from is not None and upgrade_to is None:
-            env = { "envs":  
-                    { 
-                    amd_latest: upgrade_from
-                }
-            } 
+            env = {"envs": {amd_latest: upgrade_from}}
             if "arm64" in upgrade_from or "aarch64" in upgrade_from:
-                env = {"envs":  
-                     { amd_latest: base_image,
-                       arm_latest: upgrade_from
-                    }
-                } 
+                env = {"envs": {amd_latest: base_image, arm_latest: upgrade_from}}
 
-        data = {"job_execution_type": "1", 
-                "pod_spec_options": 
-                env
-            }
+        data = {"job_execution_type": "1", "pod_spec_options": env}
         print(data)
         return data
-    
+
     def get_sha(self, url):
         res = requests.get(url=url, headers=self.get_github_headers())
         if res.status_code == 200:
@@ -126,7 +93,7 @@ class Jobs(object):
         else:
             print(res.status_code, res.reason)
             return None
-        
+
     def push_action(self, url, data):
         res = requests.put(url=url, json=data, headers=self.get_github_headers())
         if res.status_code == 200:
@@ -135,51 +102,83 @@ class Jobs(object):
             print(res.status_code, res.reason)
 
     def push_versions(self, content, file, run):
-        url = "https://api.github.com/repos/openshift/release-tests/contents/_releases/{}?ref=record".format(file)
-        base64Content = base64.b64encode(bytes(content, encoding='utf-8')).decode('utf-8')
+        url = "https://api.github.com/repos/openshift/release-tests/contents/_releases/{}?ref=record".format(
+            file
+        )
+        base64Content = base64.b64encode(bytes(content, encoding="utf-8")).decode(
+            "utf-8"
+        )
         # print(base64Content)
         # check if the file exist
         res = requests.get(url=url, headers=self.get_github_headers())
         if res.status_code == 200:
             oldVersion = self.get_recored_version(url)
-            if VersionInfo.parse(oldVersion) < VersionInfo.parse(content): 
+            if VersionInfo.parse(oldVersion) < VersionInfo.parse(content):
                 sha = self.get_sha(url)
                 # sha is Required if you are updating a file.
-                data = {"sha": sha,"content": base64Content,"branch": "record", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
+                data = {
+                    "sha": sha,
+                    "content": base64Content,
+                    "branch": "record",
+                    "message": "got the latest version %s" % content,
+                    "committer": {
+                        "name": "Release Bot",
+                        "email": "jianzhanbjz@github.com",
+                    },
+                }
                 self.push_action(url, data)
                 if run:
-                    default_file= "_releases/required-jobs.json"
+                    default_file = "_releases/required-jobs.json"
                     channel = content[:-2]
                     self.run_required_jobs(channel, default_file, content)
             else:
-                print("No update! since the recored version %s >= the new version %s" % (oldVersion, content))
+                print(
+                    "No update! since the recored version %s >= the new version %s"
+                    % (oldVersion, content)
+                )
         elif res.status_code == 404:
             print("file %s doesn't exist, create it." % url)
-            data = {"content":base64Content,"branch": "record", "message":"got the latest version %s" % content,"committer":{"name":"Release Bot","email":"jianzhanbjz@github.com"}}
+            data = {
+                "content": base64Content,
+                "branch": "record",
+                "message": "got the latest version %s" % content,
+                "committer": {"name": "Release Bot", "email": "jianzhanbjz@github.com"},
+            }
             self.push_action(url, data)
             if run:
-                default_file= "_releases/required-jobs.json"
+                default_file = "_releases/required-jobs.json"
                 channel = content[:-2]
                 self.run_required_jobs(channel, default_file, content)
         else:
             print("Push error: %s, %s" % (res.status_code, res.reason))
-    
+
     def save_results(self, content, file):
         file_json = file
-        url = "https://api.github.com/repos/openshift/release-tests/contents/_releases/" + file
-        base64Content = base64.b64encode(bytes(content, encoding='utf-8')).decode('utf-8')
+        url = (
+            "https://api.github.com/repos/openshift/release-tests/contents/_releases/"
+            + file
+        )
+        base64Content = base64.b64encode(bytes(content, encoding="utf-8")).decode(
+            "utf-8"
+        )
         # print(base64Content)
         # check if the file exist
-        res = requests.get(url=url, headers=self.get_github_headers())       
+        res = requests.get(url=url, headers=self.get_github_headers())
 
-    def get_recored_version(self,url):
+    def get_recored_version(self, url):
         try:
             # it will use the default master branch
             res = requests.get(url=url, headers=self.get_github_headers())
             if res.status_code == 200:
-                return base64.b64decode(json.loads(res.text)["content"]).decode('utf-8').replace("\n", "")
+                return (
+                    base64.b64decode(json.loads(res.text)["content"])
+                    .decode("utf-8")
+                    .replace("\n", "")
+                )
             else:
-                print("Fail to get recored version! %s:%s" % (res.status_code, res.reason))
+                print(
+                    "Fail to get recored version! %s:%s" % (res.status_code, res.reason)
+                )
                 return None
         except Exception as e:
             print(e)
@@ -198,36 +197,49 @@ class Jobs(object):
         # releaseVersions = ["4.10.0", "4.11.0", "4.12.0"]
         for version in version_list:
             print("getting the latest payload of %s" % version)
-            for tag in dict['tags']:
-                if tag['phase'] == 'Accepted':
-                    new = VersionInfo.parse(tag['name'])
+            for tag in dict["tags"]:
+                if tag["phase"] == "Accepted":
+                    new = VersionInfo.parse(tag["name"])
                     old = VersionInfo.parse(version)
                     if new >= old:
                         if new.minor == old.minor:
                             channel = version[:-2]
-                            print("The latest version of %s is: %s" %(channel,tag['name']))
+                            print(
+                                "The latest version of %s is: %s"
+                                % (channel, tag["name"])
+                            )
                             file = "Auto-OCP-%s.txt" % version[:-2]
                             if push:
-                                self.push_versions(content=tag['name'], file=file, run=run)
+                                self.push_versions(
+                                    content=tag["name"], file=file, run=run
+                                )
                             break
                         # else:
                         #     print("Not in the same Y release: %s" % new)
 
     def save_job_data(self, dict):
-         # save it to the crrent CSV file
-         with open('/tmp/prow-jobs.csv', 'a', newline='', encoding='utf-8') as f:
+        # save it to the crrent CSV file
+        with open("/tmp/prow-jobs.csv", "a", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            L = [dict['jobName'], dict['payload'], dict['upgrade_from'], dict['upgrade_to'], dict['time'], dict['jobID'], dict['jobURL']]
+            L = [
+                dict["jobName"],
+                dict["payload"],
+                dict["upgrade_from"],
+                dict["upgrade_to"],
+                dict["time"],
+                dict["jobID"],
+                dict["jobURL"],
+            ]
             writer.writerow(L)
 
-    # get_github_headers func adds Github Token in case rate limit   
+    # get_github_headers func adds Github Token in case rate limit
     def get_github_headers(self):
-        token = os.getenv('GITHUB_TOKEN')
+        token = os.getenv("GITHUB_TOKEN")
         if token:
-            headers = {'Authorization': 'Bearer ' + token.strip()}
+            headers = {"Authorization": "Bearer " + token.strip()}
             return headers
         else:
-            print('No GITHUB_TOKEN found, exit...')
+            print("No GITHUB_TOKEN found, exit...")
             sys.exit(0)
 
     def get_required_jobs(self, file_path):
@@ -251,9 +263,13 @@ class Jobs(object):
                     for job in job_dict[channel]:
                         print("Hanling %s" % job)
                         # amd64 as default
-                        payload = "quay.io/openshift-release-dev/ocp-release:{}-x86_64".format(version)
+                        payload = "quay.io/openshift-release-dev/ocp-release:{}-x86_64".format(
+                            version
+                        )
                         if "arm64" in job:
-                            payload = "quay.io/openshift-release-dev/ocp-release:{}-aarch64".format(version)
+                            payload = "quay.io/openshift-release-dev/ocp-release:{}-aarch64".format(
+                                version
+                            )
                         # specify the latest stable payload for upgrade test
                         if "upgrade-from-stable" in job:
                             self.run_job(job, None, None, upgrade_to=payload)
@@ -267,7 +283,7 @@ class Jobs(object):
     # run_job func runs job by calling the API
     def run_job(self, jobName, payload, upgrade_from, upgrade_to):
         if jobName is None:
-            print('Error! Please input the correct prow job name!')
+            print("Error! Please input the correct prow job name!")
         elif jobName.startswith("periodic-ci-"):
             periodicJob = jobName.strip()
         else:
@@ -275,9 +291,13 @@ class Jobs(object):
             periodicJob = self.search_job(jobName, None)
 
         if periodicJob is not None:
-            url = self.gangwayURL+periodicJob.strip()
+            url = self.gangwayURL + periodicJob.strip()
 
-            res = requests.post(url=url, json=self.get_job_data(payload, upgrade_from, upgrade_to), headers=self.get_prow_headers())
+            res = requests.post(
+                url=url,
+                json=self.get_job_data(payload, upgrade_from, upgrade_to),
+                headers=self.get_prow_headers(),
+            )
             if res.status_code == 200:
                 # print(res.text)
                 job_id = json.loads(res.text)["id"]
@@ -289,46 +309,59 @@ class Jobs(object):
             print("Warning! Couldn't find job:%s" % jobName)
 
     def search_job(self, jobName, ocp_version):
-        print('Searching job...')
-        jobURLs = 'https://api.github.com/repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/?ref=master'
+        print("Searching job...")
+        jobURLs = "https://api.github.com/repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/?ref=master"
         req = requests.get(url=jobURLs, timeout=3)
         if req.status_code == 200:
             file_dict = yaml.load(req.text, Loader=yaml.FullLoader)
             for file in file_dict:
-                fileName = file['name'].strip()
+                fileName = file["name"].strip()
                 if ocp_version is not None and ocp_version not in fileName:
                     continue
-                if fileName.endswith('.yaml') and 'periodics' in fileName:
+                if fileName.endswith(".yaml") and "periodics" in fileName:
                     print(">>>> " + fileName)
-                    url = 'https://api.github.com/repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/{}?ref=master'.format(fileName)
-                    res=requests.get(url=url, headers=self.get_github_headers(), timeout=3)
+                    url = "https://api.github.com/repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/{}?ref=master".format(
+                        fileName
+                    )
+                    res = requests.get(
+                        url=url, headers=self.get_github_headers(), timeout=3
+                    )
                     if res.status_code == 200:
                         # We have to get the git blobs when the size is very large, such as
                         # git_url = 'https://api.github.com/repos/openshift/release/git/blobs/7546acab2fdc5fcde2df8d549df1d2886fcb4efc'
-                        git_url = res.json()['git_url']
-                        res = requests.get(url=git_url, headers=self.get_github_headers(), timeout=3)
+                        git_url = res.json()["git_url"]
+                        res = requests.get(
+                            url=git_url, headers=self.get_github_headers(), timeout=3
+                        )
                         if res.status_code == 200:
-                            content = base64.b64decode(res.json()['content'].replace("\n", "")).decode('utf-8')
+                            content = base64.b64decode(
+                                res.json()["content"].replace("\n", "")
+                            ).decode("utf-8")
                             job_dict = yaml.load(content, Loader=yaml.FullLoader)
                             if job_dict is None:
-                                print("Warning! Couldn't get retunred JSON content when scanning %s!" % fileName)
+                                print(
+                                    "Warning! Couldn't get retunred JSON content when scanning %s!"
+                                    % fileName
+                                )
                                 continue
                             if jobName is not None:
-                                for job in job_dict['periodics']:
-                                    if jobName in job['name']:
-                                        return job['name']
+                                for job in job_dict["periodics"]:
+                                    if jobName in job["name"]:
+                                        return job["name"]
                             else:
                                 return job_dict
 
-    def get_job_results(self, jobID, jobName=None, payload=None, upgrade_from=None, upgrade_to=None):
+    def get_job_results(
+        self, jobID, jobName=None, payload=None, upgrade_from=None, upgrade_to=None
+    ):
         if jobID:
             req = requests.get(url=self.prowJobURL.format(jobID.strip()))
             if req.status_code == 200:
                 # the returned content is not the standard JSON format so use RE instead
                 # jsonData = json.loads(req.text)
                 # jsonData = req.json()
-                urlPattern = re.compile('.*url: (.*)\n$', re.S)
-                timePattern = re.compile('.*creationTimestamp: \"(.*?)\"', re.S)
+                urlPattern = re.compile(".*url: (.*)\n$", re.S)
+                timePattern = re.compile('.*creationTimestamp: "(.*?)"', re.S)
                 urlList = urlPattern.findall(req.text)
                 timeList = timePattern.findall(req.text)
                 if len(urlList) == 1 and len(timeList) == 1:
@@ -336,22 +369,24 @@ class Jobs(object):
                     createTime = timeList[0]
                     print(jobName, payload, jobID, createTime, jobURL)
                     dict = {
-                        'jobName': jobName,
-                        'payload': payload,
-                        'upgrade_from': upgrade_from,
-                        'upgrade_to': upgrade_to,
-                        'time' : createTime,
-                        'jobID' : jobID,
-                        'jobURL' : jobURL
+                        "jobName": jobName,
+                        "payload": payload,
+                        "upgrade_from": upgrade_from,
+                        "upgrade_to": upgrade_to,
+                        "time": createTime,
+                        "jobID": jobID,
+                        "jobURL": jobURL,
                     }
                     self.save_job_data(dict=dict)
                     print("Done.")
                 else:
                     print("Not found the url link or creationTimestamp...")
             else:
-                raise Exception("return status code:%s reason:%s" % (req.status_code, req.reason))
+                raise Exception(
+                    "return status code:%s reason:%s" % (req.status_code, req.reason)
+                )
         else:
-            print('No job ID input, exit...')
+            print("No job ID input, exit...")
             sys.exit(0)
 
     def list_jobs(self, component, branch):
@@ -359,44 +394,59 @@ class Jobs(object):
             component = "openshift/openshift-tests-private"
         if branch is None:
             branch = "master"
-        baseURL = 'https://api.github.com/repos/openshift/release/contents/ci-operator/config/%s/?ref=%s' % (component, branch)
+        baseURL = (
+            "https://api.github.com/repos/openshift/release/contents/ci-operator/config/%s/?ref=%s"
+            % (component, branch)
+        )
         req = requests.get(url=baseURL, timeout=3)
         if req.status_code == 200:
             file_dict = yaml.load(req.text, Loader=yaml.FullLoader)
             file_count = 0
             for file in file_dict:
-                if file['name'].endswith('.yaml'):
-                    url = self.jobURL.format(file['name'].strip())
+                if file["name"].endswith(".yaml"):
+                    url = self.jobURL.format(file["name"].strip())
                     print(url)
                     self.get_jobs(url)
                     file_count += 1
-            print("Total file number under %s folder is:%s" % (component, str(file_count)))
+            print(
+                "Total file number under %s folder is:%s" % (component, str(file_count))
+            )
         else:
             print(req.reason)
-    def get_jobs(self,url):
+
+    def get_jobs(self, url):
         try:
-            res=requests.get(url=url, headers=self.get_github_headers(), timeout=3)
+            res = requests.get(url=url, headers=self.get_github_headers(), timeout=3)
             if res.status_code == 200:
-                content = base64.b64decode(res.json()['content'].replace("\n", "")).decode('utf-8')
+                content = base64.b64decode(
+                    res.json()["content"].replace("\n", "")
+                ).decode("utf-8")
                 job_dict = yaml.load(content, Loader=yaml.FullLoader)
                 api_count = 0
-                for job in job_dict['tests']:
-                    api = 'true'
+                for job in job_dict["tests"]:
+                    api = "true"
                     api_count += 1
-                    print(job['as'] + "   " + api)
-                print('Total number of api job is: ' + str(api_count))
+                    print(job["as"] + "   " + api)
+                print("Total number of api job is: " + str(api_count))
             else:
-                print('warning:' + res.reason)
+                print("warning:" + res.reason)
         except Exception as e:
             print(e)
 
+
 job = Jobs()
+
+
 @click.group()
-@click.version_option(package_name='job')
-@click.option('--debug/--no-debug', default=False)
+@click.version_option(package_name="job")
+@click.option("--debug/--no-debug", default=False)
 def cli(debug):
-    """"This job tool based on Prow REST API(https://github.com/kubernetes/test-infra/issues/27824), used to handle those prow jobs."""
-    click.echo('Debug mode is %s' % ('on' if debug else 'off'))
+    """ "This job tool based on Prow REST API(https://github.com/kubernetes/test-infra/issues/27824), used to handle those prow jobs."""
+    click.echo("Debug mode is %s" % ("on" if debug else "off"))
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+        httpclient.HTTPConnection.debuglevel = 1
+
 
 @cli.command("get_results")
 @click.argument("job_id")
@@ -405,44 +455,66 @@ def get_cmd(job_id):
     """Return the Prow job executed info."""
     job.get_job_results(job_id)
 
+
 @cli.command("run")
 @click.argument("job_name")
-@click.option("--payload", help="specify a payload for e2e test, if not, it will use the latest payload from https://amd64.ocp.releases.ci.openshift.org/")
+@click.option(
+    "--payload",
+    help="specify a payload for e2e test, if not, it will use the latest payload from https://amd64.ocp.releases.ci.openshift.org/",
+)
 @click.option("--upgrade_from", help="specify an original payload for upgrade test.")
 @click.option("--upgrade_to", help="specify a target payload for upgrade test.")
 def run_cmd(job_name, payload, upgrade_from, upgrade_to):
-    """Run a job and save results to /tmp/prow-jobs.csv. \n 
+    """Run a job and save results to /tmp/prow-jobs.csv. \n
     For ARM test, we hard code a x86 image as the base image. Details: https://issues.redhat.com/browse/DPTP-3538
     """
     job.run_job(job_name, payload, upgrade_from, upgrade_to)
 
+
 @cli.command("list")
-@click.option("--component", help="The detault is 'openshift/openshift-tests-private': https://github.com/openshift/release/tree/master/ci-operator/config/openshift/openshift-tests-private ")
+@click.option(
+    "--component",
+    help="The detault is 'openshift/openshift-tests-private': https://github.com/openshift/release/tree/master/ci-operator/config/openshift/openshift-tests-private ",
+)
 @click.option("--branch", help="the master branch is as default.")
 def run_cmd(component, branch):
     """List the jobs which support the API call."""
     job.list_jobs(component, branch)
 
+
 @cli.command("run_required")
-@click.option("--channel", help="The OCP minor version, if multi versions, comma spacing, such as 4.12,4.11")
+@click.option(
+    "--channel",
+    help="The OCP minor version, if multi versions, comma spacing, such as 4.12,4.11",
+)
 @click.option("--file", help="a file that stores required jobs for all OCP versions.")
 @click.option("--version", help="OCP version, such as 4.10.63")
 def run_cmd(channel, file, version):
     """Run required jobs from a file. Note that: this command only run stable payload, not nightly!
-    For example, $ job run_required --channel 4.10 --file _releases/required-jobs.json --version 4.10.63    
+    For example, $ job run_required --channel 4.10 --file _releases/required-jobs.json --version 4.10.63
     """
     job.run_required_jobs(channel, file, version)
 
+
 @cli.command("get_payloads")
 @click.argument("versions")
-@click.option("--push", default=False, help="push the info to the https://api.github.com/repos/openshift/release-tests/contents/_releases/")
-@click.option("--run", default=False, help="Run the jobs stored in the _releases/required-jobs.json file if any updates. Note that: it won't be executed if --push is False")
+@click.option(
+    "--push",
+    default=False,
+    help="push the info to the https://api.github.com/repos/openshift/release-tests/contents/_releases/",
+)
+@click.option(
+    "--run",
+    default=False,
+    help="Run the jobs stored in the _releases/required-jobs.json file if any updates. Note that: it won't be executed if --push is False",
+)
 def run_payloads(versions, push, run):
     """Check the latest stable payload of each version. Use comma spacing if multi versions, such as, 4.10.0,4.11.0,4.12.0"""
     job.get_payloads(versions, push, run)
 
-if __name__ == '__main__':
-    start=time.time()
+
+if __name__ == "__main__":
+    start = time.time()
     cli()
-    end=time.time()
-    print('execute time cost:%.2f'%(end-start))
+    end = time.time()
+    print("execute time cost:%.2f" % (end - start))


### PR DESCRIPTION
if the job name is incorrect, it only can be checked in resp headers
```
 job --debug run periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-openshift-logging-5.7-aws-ipi-proxy-sdn-workers-rhel8-p1-f7 --payload registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-07-05-213721
Debug mode is on
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-07-05-213721'}}}
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): gangway-ci.apps.ci.l2s4.p1.openshiftapps.com:443
send: b'CONNECT gangway-ci.apps.ci.l2s4.p1.openshiftapps.com:443 HTTP/1.0\r\n\r\n'
send: b'POST /v1/executions/periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-openshift-logging-5.7-aws-ipi-proxy-sdn-workers-rhel8-p1-f7 HTTP/1.1\r\nHost: gangway-ci.apps.ci.l2s4.p1.openshiftapps.com\r\nUser-Agent: python-requests/2.28.2\r\nAccept-Encoding: gzip, deflate, br\r\nAccept: */*\r\nConnection: keep-alive\r\nAuthorization: Bearer sha256~kRnwrmdQVWQ7B-4U1KNTiJa2LepfSJP_-Za8hUMGahQ\r\nContent-Length: 159\r\nContent-Type: application/json\r\n\r\n'
send: b'{"job_execution_type": "1", "pod_spec_options": {"envs": {"RELEASE_IMAGE_LATEST": "registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-07-05-213721"}}}'
reply: 'HTTP/1.1 500 Internal Server Error\r\n'
header: content-length: 0
header: content-type: application/grpc
header: date: Thu, 06 Jul 2023 09:20:28 GMT
header: gap-auth: rioliu@cluster.local
header: gap-upstream-address: localhost:32001
header: grpc-message: failed to find associated periodic job "periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-openshift-logging-5.7-aws-ipi-proxy-sdn-workers-rhel8-p1-f7"
header: grpc-status: 2
header: server: envoy
header: x-envoy-upstream-service-time: 0
header: set-cookie: 06b938ad9fd6bb54f16617135611e13f=ca0c9c9dec921b1f7b287177e39933b8; path=/; HttpOnly; Secure; SameSite=None
DEBUG:urllib3.connectionpool:https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com:443 "POST /v1/executions/periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-openshift-logging-5.7-aws-ipi-proxy-sdn-workers-rhel8-p1-f7 HTTP/1.1" 500 0
Error code: 500, reason: Internal Server Error
```