### PR TITLE
raise error if test report already exists

### DIFF
--- a/oar/core/worksheet_mgr.py
+++ b/oar/core/worksheet_mgr.py
@@ -63,7 +63,10 @@ class WorksheetManager:
             # check report worksheet exists or not, if yes, skip duplicating
             try:
                 existing_sheet = self._doc.worksheet(self._cs.release)
-                self._report = TestReport(existing_sheet, self._cs)
+                if existing_sheet:
+                    raise WorksheetException(
+                        f"test report of {self._cs.release} already exists, url: {existing_sheet.url}"
+                    )
             except WorksheetNotFound:
                 new_sheet = self._doc.duplicate_sheet(self._template.id)
                 new_sheet.update_title(self._cs.release)


### PR DESCRIPTION
```
 oar -r 4.12.25 create-test-report
^@^@^@^@^@^@^@^@^@2023-07-20T12:30:47Z: ERROR: create new test report failed  Traceback (most recent call last):
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/cmd_create_test_report.py", line 21, in create_test_report
    report = wm.create_test_report()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/core/worksheet_mgr.py", line 67, in create_test_report
    raise WorksheetException(
oar.core.exceptions.WorksheetException: test report of 4.12.25 exists, url: https://docs.google.com/spreadsheets/d/1NNIzctvTC6zhYD7nFyFSgrJ3E8CF5qCU8iJbDhZyzAM#gid=1115454007
Traceback (most recent call last):
  File "/usr/local/bin/oar", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/__main__.py", line 6, in main
    cli(obj={})
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/cmd_create_test_report.py", line 21, in create_test_report
    report = wm.create_test_report()
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/core/worksheet_mgr.py", line 67, in create_test_report
    raise WorksheetException(
oar.core.exceptions.WorksheetException: test report of 4.12.25 exists, url: https://docs.google.com/spreadsheets/d/1NNIzctvTC6zhYD7nFyFSgrJ3E8CF5qCU8iJbDhZyzAM#gid=1115454007
```