### PR TITLE
fix push-to-cdn-staging issue

### DIFF
--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -145,7 +145,7 @@ class AdvisoryManager:
             ads = self.get_advisories()
             for ad in ads:
                 if not ad.are_all_push_jobs_completed():
-                    ad.push_to_cdn()
+                    ad.push_to_cdn("stage")
                     triggered = True
         except Exception as e:
             raise AdvisoryException("push to cdn failed") from e


### PR DESCRIPTION
issue:
2023-07-21T18:54:21Z: INFO: checking push job status for advisory 117560 ...
Traceback (most recent call last):
  File "/home/wewang/522/release-tests/oar/core/advisory_mgr.py", line 148, in push_to_cdn_staging
    ad.push_to_cdn()
TypeError: Advisory.push_to_cdn() missing 1 required positional argument: 'target'

The above exception was the direct cause of the following exception:
 
fixed result:
2023-07-21T18:59:14Z: INFO: checking push job status for advisory 117560 ...
Traceback (most recent call last):
  File "/home/wewang/522/release-tests/oar/core/advisory_mgr.py", line 148, in push_to_cdn_staging
    ad.push_to_cdn("")
  File "/home/wewang/522/release-tests/oar/core/advisory_mgr.py", line 354, in push_to_cdn
    self.push()
  File "/home/wewang/.local/lib/python3.10/site-packages/errata_tool/erratum.py", line 1016, in push
    self._processResponse(r)
  File "/home/wewang/.local/lib/python3.10/site-packages/errata_tool/connector.py", line 239, in _processResponse
    raise ErrataException(err_msg)
errata_tool.exception.ErrataException: Erratum 117560: cdn_stage: Can't push advisory to Cdn Stage now due to: CVP tests for operator builds must complete
cdn_docker_stage: Can't push advisory to Cdn Docker Stage now due to: CVP tests for operator builds must complete

@rioliu-rh could you help to check, thanks