### PR TITLE
add installation test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+install:
+	python3 -m pip install --upgrade pip && pip3 install -e . && oar -h


### PR DESCRIPTION
As title, but `oar -h` fail to run, @rioliu-rh do you happen to know why?
```console
MacBook-Pro:release-tests jianzhang$ make install
python3 -m pip install --upgrade pip && pip3 install -e . && oar -h
...
Successfully installed oar-0.1.dev108+ge88dabe
Traceback (most recent call last):
  File "/opt/homebrew/bin/oar", line 5, in <module>
    from oar.cli.__main__ import main
ImportError: cannot import name 'main' from 'oar.cli.__main__' (/opt/homebrew/lib/python3.11/site-packages/release_tests-1.0.0-py3.11.egg/oar/cli/__main__.py)
make: *** [install] Error 1

MacBook-Pro:release-tests jianzhang$ oar -h
Traceback (most recent call last):
  File "/opt/homebrew/bin/oar", line 5, in <module>
    from oar.cli.__main__ import main
ImportError: cannot import name 'main' from 'oar.cli.__main__' (/opt/homebrew/lib/python3.11/site-packages/release_tests-1.0.0-py3.11.egg/oar/cli/__main__.py)

```