### PR TITLE
Fix issue for create test report when errata is not ready

### DIFF
--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -43,10 +43,10 @@ def print_version(ctx, param, value):
 def cli(ctx, release, debug):
     util.init_logging(logging.DEBUG if debug else logging.INFO)
     try:
-        cs = ConfigStore(release)
+        ConfigStore(release)
     except ConfigStoreException as cse:
         logger.exception("config store initialization failed")
-
+    cs = ConfigStore(release)
     ctx.ensure_object(dict)
     ctx.obj["cs"] = cs
 

--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -42,10 +42,6 @@ def print_version(ctx, param, value):
 @click.option("-v", "--debug", help="enable debug logging", is_flag=True, default=False)
 def cli(ctx, release, debug):
     util.init_logging(logging.DEBUG if debug else logging.INFO)
-    try:
-        ConfigStore(release)
-    except ConfigStoreException as cse:
-        logger.exception("config store initialization failed")
     cs = ConfigStore(release)
     ctx.ensure_object(dict)
     ctx.obj["cs"] = cs

--- a/oar/core/config_store.py
+++ b/oar/core/config_store.py
@@ -55,7 +55,7 @@ class ConfigStore:
         if self.release in self._build_data["releases"]:
             self._assembly = self._build_data["releases"][self.release]["assembly"]
         else:
-            raise ConfigStoreException(f"[{self.release}] advisories are not ready, cannot create test report, you can check:{url}")
+            raise ConfigStoreException(f"[{self.release}] build data is not ready, cannot create test report, you can check:{url}")
 
     def get_advisories(self):
         """

--- a/oar/core/config_store.py
+++ b/oar/core/config_store.py
@@ -52,8 +52,10 @@ class ConfigStore:
                 self._build_data = yaml.safe_load(response.text)
             except yaml.YAMLError as ye:
                 raise ConfigStoreException("ocp build data format is invalid") from ye
-
-        self._assembly = self._build_data["releases"][self.release]["assembly"]
+        if self.release in self._build_data["releases"]:
+            self._assembly = self._build_data["releases"][self.release]["assembly"]
+        else:
+            raise ConfigStoreException(f"[{self.release}] advisories are not ready, cannot create test report, you can check:{url}")
 
     def get_advisories(self):
         """


### PR DESCRIPTION
@rioliu-rh  please check it, thanks
when create 4.13.7 report, which errata is not ready, 
original output is:
$oar -r 4.13.7 create-test-report
'4.13.7'

so fixed it, when errata is not ready, should give info about the reason, 
fixed output:
$oar -r 4.13.7 create-test-report
2023-07-27T13:11:58Z: ERROR: config store initialization failed
Traceback (most recent call last):
  File "/home/wewang/522/release-tests/oar/cli/cmd_group.py", line 46, in cli
    ConfigStore(release)
  File "/home/wewang/522/release-tests/oar/core/config_store.py", line 58, in __init__
    raise ConfigStoreException(f"[{self.release}] advisories are not ready, cannot create test report,you can check:{url}")
oar.core.exceptions.ConfigStoreException: [4.13.7] advisories are not ready, cannot create test report,you can check:https://raw.githubusercontent.com/openshift-eng/ocp-build-data/openshift-4.13/releases.yml
