### PR TITLE
add required jobs for 4.9

### DIFF
--- a/_releases/required-jobs.json
+++ b/_releases/required-jobs.json
@@ -1,4 +1,11 @@
 { 
+    "4.9" : [
+        "periodic-ci-openshift-openshift-tests-private-release-4.9-amd64-nightly-4.9-upgrade-from-stable-4.9-aws-ipi-ovn-fips-cert-rotation-p2-f360",
+        "periodic-ci-openshift-openshift-tests-private-release-4.9-amd64-nightly-4.9-upgrade-from-stable-4.9-azure-ipi-fips-cert-rotation-p2-f360",
+        "periodic-ci-openshift-openshift-tests-private-release-4.9-amd64-nightly-4.9-upgrade-from-stable-4.9-gcp-ipi-ovn-ipsec-fips-cert-rotation-p2-f360",
+        "periodic-ci-openshift-openshift-tests-private-release-4.9-amd64-nightly-4.9-upgrade-from-stable-4.9-vsphere-ipi-proxy-fips-cert-rotation-p2-f360",
+        "periodic-ci-openshift-openshift-tests-private-release-4.9-amd64-nightly-4.9-upgrade-from-stable-4.9-baremetalds-ipi-ovn-ipv4-fips-cert-rotation-p2-f360"
+    ],
     "4.10" : [
         "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28",
         "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28",


### PR DESCRIPTION
As title, updates based on https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/openshift-tests-private 