### PR TITLE
don't initialize config store with help option

### DIFF
--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -42,9 +42,15 @@ def print_version(ctx, param, value):
 @click.option("-v", "--debug", help="enable debug logging", is_flag=True, default=False)
 def cli(ctx, release, debug):
     util.init_logging(logging.DEBUG if debug else logging.INFO)
-    cs = ConfigStore(release)
-    ctx.ensure_object(dict)
-    ctx.obj["cs"] = cs
+    is_help = False
+    for k in CONTEXT_SETTINGS["help_option_names"]:
+        if k in sys.argv:
+            is_help = True
+            break
+    if not is_help:
+        cs = ConfigStore(release)
+        ctx.ensure_object(dict)
+        ctx.obj["cs"] = cs
 
 
 cli.add_command(create_test_report)


### PR DESCRIPTION
enhancement: don't initialize config store (download ocp data from remote) if the command has help option
```console
oar -r 4.12.25 check-greenwave-cvp-tests -h
Usage: oar check-greenwave-cvp-tests [OPTIONS]

  Check Greenwave CVP test results for all advisories

Options:
  -h, --help  Show this message and exit.

oar -r 4.12.25 check-greenwave-cvp-tests --help
Usage: oar check-greenwave-cvp-tests [OPTIONS]

  Check Greenwave CVP test results for all advisories

Options:
  -h, --help  Show this message and exit.
```