### PR TITLE
update k8sgtp dockerfile

### DIFF
--- a/prow/Dockerfile.k8sgpt
+++ b/prow/Dockerfile.k8sgpt
@@ -5,5 +5,6 @@ RUN git clone https://github.com/k8sgpt-ai/k8sgpt.git && \
     cd k8sgpt && \
     go mod vendor && \
     make build
-ENTRYPOINT ["./k8sgpt/bin/k8sgpt"]
+RUN cp ./k8sgpt/bin/k8sgpt /usr/bin/
+ENTRYPOINT ["k8sgpt"]
 


### PR DESCRIPTION
Address this failure: https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/42096/rehearse-42096-periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-alibaba-ipi-private-fips-f28/1689506642434985984
```console
INFO[2023-08-10T06:17:13Z] /bin/bash: line 11: k8sgpt: command not found
```
