### PR TITLE
make email as required option for cmd take-ownership

### DIFF
--- a/oar/cli/cmd_take_ownership.py
+++ b/oar/cli/cmd_take_ownership.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
     "-e",
     "--email",
     required=True,
-    help="email address of the owner, if option is not set, will use default owner setting instead",
+    help="email address of the owner",
 )
 @click.pass_context
 def take_ownership(ctx, email):

--- a/oar/cli/cmd_take_ownership.py
+++ b/oar/cli/cmd_take_ownership.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "-e",
     "--email",
+    required=True,
     help="email address of the owner, if option is not set, will use default owner setting instead",
 )
 @click.pass_context
@@ -24,10 +25,7 @@ def take_ownership(ctx, email):
     """
     # get config store from context
     cs = ctx.obj["cs"]
-    if not email:
-        logger.warn("email option is not set, will use default setting")
-    else:
-        cs.set_owner(email)
+    cs.set_owner(email)
 
     try:
         # get existing report

--- a/oar/core/config_store.json
+++ b/oar/core/config_store.json
@@ -20,9 +20,9 @@
                 "id": "release-artists"
             },
             "approver": {
-                "channel":"#forum-ocp-release",
+                "channel": "#forum-ocp-release",
                 "doc_id": "docs-rel-notes",
-                "prodsec_id" : "ahanwate@redhat.com,sfowler@redhat.com"
+                "prodsec_id": "ahanwate@redhat.com,sfowler@redhat.com"
             },
             "qe-forum": {
                 "channel": "#forum-openshift-qe",


### PR DESCRIPTION
- make email as required option for cmd take-ownership
- reformat config_store.json

```console
Usage: oar take-ownership [OPTIONS]

  Take ownership for advisory and jira subtasks

Options:
  -e, --email TEXT  email address of the owner  [required]
  -h, --help        Show this message and exit.
```