### PR TITLE
[OCPQE-16445]support nightly build for image consistency check job

### DIFF
--- a/oar/core/config_store.py
+++ b/oar/core/config_store.py
@@ -89,7 +89,6 @@ class ConfigStore:
         except KeyError:
             logger.warn("<reference_releases> is not found in releases.yml")
             reference_releases = {}
-
         return reference_releases
 
     def get_jira_ticket(self):

--- a/oar/core/jenkins_helper.py
+++ b/oar/core/jenkins_helper.py
@@ -34,9 +34,10 @@ class JenkinsHelper:
                 "call stage pipeline job failed") from ej
         return build_url
 
-    def call_image_consistency_job(self):
+    def call_image_consistency_job(self, pull_spec):
         try:
-            build_url = self.call_build_job("image-consistency-check")
+            logger.info(f"triggered a job with {pull_spec}")
+            build_url = self.call_build_job("image-consistency-check", pull_spec)
         except JenkinsException as ej:
             raise JenkinsHelperException(
                 "call image-consistency-check pipeline job failed"
@@ -121,7 +122,7 @@ class JenkinsHelper:
 
         return False
 
-    def call_build_job(self, job_name):
+    def call_build_job(self, job_name, pull_spec):
         """
         trigger build job and return build url
         """
@@ -132,7 +133,7 @@ class JenkinsHelper:
                 parameters_value = {
                     "VERSION": "v" + self.version,
                     "ERRATA_NUMBERS": self.errata_numbers,
-                    "PAYLOAD_URL": self.pull_spec,
+                    "PAYLOAD_URL": pull_spec,
                 }
             elif (job_name == JENKINS_JOB_STAGE_PIPELINE):
                 parameters_value = {


### PR DESCRIPTION
if no -c option , default using stable build to test:
$oar -r 4.12.28 image-consistency-check
![image](https://github.com/openshift/release-tests/assets/12492932/bb2694ea-d7c8-40f8-9e43-772098ce805b)

if -c option, use nightly build to test:
$oar -r 4.12.28 image-consistency-check -c
![image](https://github.com/openshift/release-tests/assets/12492932/ccdb6a65-905f-4320-99a9-5941f402563a)

if has -n option and -c option, will give error info:
![image](https://github.com/openshift/release-tests/assets/12492932/d639e82d-9ed2-457a-b210-8a2566abe2a8)
