### PR TITLE
fix google sheet request quota limit issue

### DIFF
--- a/oar/core/worksheet_mgr.py
+++ b/oar/core/worksheet_mgr.py
@@ -38,12 +38,15 @@ class WorksheetManager:
                     ],
                 )
             except Exception as ce:
-                raise WorksheetException("init cred with SA file failed") from ce
+                raise WorksheetException(
+                    "init cred with SA file failed") from ce
         else:
-            raise WorksheetException(f"SA file path is invalid: {sa_file_path}")
+            raise WorksheetException(
+                f"SA file path is invalid: {sa_file_path}")
 
         try:
-            self._gs = gspread.authorize(cred)
+            self._gs = gspread.authorize(
+                cred, client_factory=gspread.client.BackoffClient)
         except Exception as ge:
             raise WorksheetException("gspread auth failed") from ge
 
@@ -320,7 +323,8 @@ class TestReport:
             if issue.is_on_qa():
                 logger.debug(f"jira issue {key} is ON_QA, updating")
                 row_vals = []
-                row_vals.append(self._to_hyperlink(util.get_jira_link(key), key))
+                row_vals.append(self._to_hyperlink(
+                    util.get_jira_link(key), key))
                 row_vals.append(issue.get_qa_contact())
                 row_vals.append(issue.get_status())
                 batch_vals.append(row_vals)
@@ -365,17 +369,20 @@ class TestReport:
                 issue = jm.get_issue(bug_key)
                 # check bug status is updated or not. if yes, update it accordingly
                 if bug_status != issue.get_status():
-                    self._ws.update_acell("E" + str(row_idx), issue.get_status())
+                    self._ws.update_acell(
+                        "E" + str(row_idx), issue.get_status())
                     logger.info(
                         f"status of bug {issue.get_key()} is updated to {issue.get_status()}"
                     )
                 elif bug_key not in jira_issues:
-                    self._ws.update_acell("E" + str(row_idx), JIRA_STATUS_DROPPED)
+                    self._ws.update_acell(
+                        "E" + str(row_idx), JIRA_STATUS_DROPPED)
                     logger.info(f"bug {bug_key} is dropped")
                 else:
                     logger.info(f"bug status of {bug_key} is not changed")
             except Exception as e:
-                raise WorksheetException(f"update bug {bug_key} status failed") from e
+                raise WorksheetException(
+                    f"update bug {bug_key} status failed") from e
 
             existing_bugs.append(bug_key)
             row_idx += 1

--- a/tests/test_worksheet_mgr.py
+++ b/tests/test_worksheet_mgr.py
@@ -20,17 +20,18 @@ class TestWorksheetManager(unittest.TestCase):
 
     def step_0_create_report(self):
         self.report = self.wm.create_test_report()
-        self.assertRegex(self.report.get_advisory_info(), "112393")
+        self.assertRegex(self.report.get_advisory_info(), "114397")
         self.assertRegex(
-            self.report.get_build_info(), "4.12.0-0.nightly-2023-04-04-050651"
+            self.report.get_build_info(), "4.12.0-0.nightly-2023-05-17-133811"
         )
-        self.assertRegex(self.report.get_jira_info(), "ART-6489")
+        self.assertRegex(self.report.get_jira_info(), "ART-6821")
 
     def step_1_update_overall_status(self):
         self.report.update_overall_status_to_red()
         self.assertEqual(self.report.get_overall_status(), OVERALL_STATUS_RED)
         self.report.update_overall_status_to_green()
-        self.assertEqual(self.report.get_overall_status(), OVERALL_STATUS_GREEN)
+        self.assertEqual(self.report.get_overall_status(),
+                         OVERALL_STATUS_GREEN)
 
     def step_2_update_tasks(self):
         task_list = [


### PR DESCRIPTION
use new client `gspread.client.BackoffClient` to initialize gspread service, fix google sheet request quota limit issue. the new client has impl of with exponential backoff retries

ref: https://docs.gspread.org/en/v5.8.0/api/client.html#gspread.client.BackoffClient

```console
./test_worksheet_mgr.py::TestWorksheetManager::test_report Passed

Total number of tests expected to run: 1
Total number of tests run: 1
Total number of tests passed: 1
Total number of tests failed: 0
Total number of tests failed with errors: 0
Total number of tests skipped: 0

Finished running tests!
```