### PR TITLE
add missed argument for call stage pipeline job

### DIFF
--- a/oar/core/jenkins_helper.py
+++ b/oar/core/jenkins_helper.py
@@ -28,7 +28,8 @@ class JenkinsHelper:
 
     def call_stage_job(self):
         try:
-            build_url = self.call_build_job(JENKINS_JOB_STAGE_PIPELINE)
+            build_url = self.call_build_job(
+                JENKINS_JOB_STAGE_PIPELINE, self.pull_spec)
         except JenkinsException as ej:
             raise JenkinsHelperException(
                 "call stage pipeline job failed") from ej
@@ -37,7 +38,8 @@ class JenkinsHelper:
     def call_image_consistency_job(self, pull_spec):
         try:
             logger.info(f"triggered a job with {pull_spec}")
-            build_url = self.call_build_job("image-consistency-check", pull_spec)
+            build_url = self.call_build_job(
+                "image-consistency-check", pull_spec)
         except JenkinsException as ej:
             raise JenkinsHelperException(
                 "call image-consistency-check pipeline job failed"
@@ -139,7 +141,7 @@ class JenkinsHelper:
                 parameters_value = {
                     "VERSION": self.version,
                     "METADATA_AD": self.metadata_ad,
-                    "PULL_SPEC": self.pull_spec,
+                    "PULL_SPEC": pull_spec,
                 }
             else:
                 logger.info(f"{job_name} is not supported")


### PR DESCRIPTION
fix issue like below
```console
 2023-10-09T21:35:59Z: INFO: job id is not set, will trigger stage testing
2023-10-09T21:36:00Z: ERROR: trigger stage testing failed
Traceback (most recent call last):
  File "/home/cloud-user/release-tests/oar/cli/cmd_stage_testing.py", line 44, in stage_testing
    build_url = jh.call_stage_job()
                ^^^^^^^^^^^^^^^^^^^
  File "/home/cloud-user/release-tests/oar/core/jenkins_helper.py", line 31, in call_stage_job
    build_url = self.call_build_job(JENKINS_JOB_STAGE_PIPELINE)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: JenkinsHelper.call_build_job() missing 1 required positional argument: 'pull_spec'
```

with the fix
```cosnole
 $ oar -r 4.13.15 stage-testing
^@^@^@^@^@^@^@^@^@^@2023-10-10T10:09:46Z: INFO: job id is not set, will trigger stage testing
2023-10-10T10:09:52Z: INFO: triggered stage pipeline job: <https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/zstreams/job/Stage-Pipeline/850/>
2023-10-10T10:09:54Z: INFO: sent slack message to <#team-qe-release>
2023-10-10T10:09:55Z: INFO: task [Stage testing] status is changed to [In Progress]
```