### PR TITLE
use k8sgpt official repo instead of personal's

### DIFF
--- a/prow/Dockerfile.k8sgpt
+++ b/prow/Dockerfile.k8sgpt
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
 LABEL maintainer="jiazha@redhat.com"
 WORKDIR /go/src/github.com/k8sgpt-ai
-RUN git clone --branch kubeconfig https://github.com/jianzhangbjz/k8sgpt.git && \
+RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git && \
     cd k8sgpt && \
     go mod vendor && \
     make build


### PR DESCRIPTION
Since https://github.com/k8sgpt-ai/k8sgpt/issues/604 issue has been addressed(https://github.com/k8sgpt-ai/k8sgpt/blob/main/pkg/kubernetes/kubernetes.go#L40), use the official repo instead of mine.
```console
[cloud-user@preserve-olm-env2 prow]$ podman --runtime crun build -f Dockerfile.k8sgpt -t quay.io/olmqe/k8sgpt:vv1 .
STEP 1/6: FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
STEP 2/6: LABEL maintainer="jiazha@redhat.com"
--> Using cache 3e652b1d507977befd63bd35de6d12498bca3a06f3a9fec70c4aac567bbf0f90
--> 3e652b1d5079
STEP 3/6: WORKDIR /go/src/github.com/k8sgpt-ai
--> Using cache 6efa777f86de14b2de59224ebc13a69d8393fa76951226aeed82e2f10c08c315
--> 6efa777f86de
STEP 4/6: RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git &&     cd k8sgpt &&     go mod vendor &&     make build
Cloning into 'k8sgpt'...
Go compliance shim [][]: Forcing GOTOOLCHAIN=local
...
STEP 5/6: RUN cp ./k8sgpt/bin/k8sgpt /usr/bin/
--> 61239c732abc
STEP 6/6: ENTRYPOINT ["k8sgpt"]
COMMIT quay.io/olmqe/k8sgpt:vv1
--> 89c41a741439
Successfully tagged quay.io/olmqe/k8sgpt:vv1
89c41a741439392077da2ad107c257c8514890d54f1856fd65bb0d63fbc39128
```