### PR TITLE
OCPQE-17313 add func to check dependent advisories

### DIFF
--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -46,3 +46,11 @@ class TestAdvisoryManager(unittest.TestCase):
         doc_appr, prodsec_appr = self.am.get_doc_security_approved_ads()
         self.assertTrue(len(doc_appr) == 2)
         self.assertTrue(len(prodsec_appr) == 0)
+
+    def test_get_dependent_advisories(self):
+        ad_id = 121862
+        dependent_ad_id = 121861
+        ad = Advisory(errata_id=ad_id)
+        self.assertTrue(ad.has_dependency())
+        self.assertEqual(ad.get_dependent_advisories()[
+                         0].errata_id, dependent_ad_id)


### PR DESCRIPTION
for push to cdn staging job, we need to checkout advisory dependencies. trigger push job for dependent advisories first.

- add func `has_dependency` to check whether there is any dependent advisory
- add func `get_dependent_advisories` to get dependent advisory list
- refine func `push_to_cdn`, move func `are_all_push_jobs_completed` into this func, return boolean flag to indicate whether job is triggered or not

add unit test for this logic
```console
Running tests: release-tests/tests/test_advisory_mgr.py::TestAdvisoryManager::test_get_dependent_advisories
./test_advisory_mgr.py::TestAdvisoryManager::test_get_dependent_advisories Passed

Total number of tests expected to run: 1
Total number of tests run: 1
Total number of tests passed: 1
Total number of tests failed: 0
Total number of tests failed with errors: 0
Total number of tests skipped: 0

Finished running tests!
```

cmdline test
```console
$ oar -r 4.13.16 push-to-cdn-staging
2023-10-13T22:51:08Z: INFO: task [Pushing to CDN staging] status is changed to [In Progress]
2023-10-13T22:52:33Z: INFO: advisory 121858 has dependent advisory [121862, 121860]
^@2023-10-13T22:53:16Z: INFO: checking push job status for advisory 121862 ...
2023-10-13T22:53:18Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:53:18Z: INFO: checking push job status for advisory 121860 ...
2023-10-13T22:53:20Z: INFO: push job for target <cdn_docker_stage> is COMPLETE
2023-10-13T22:53:20Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:53:20Z: INFO: checking push job status for advisory 121858 ...
2023-10-13T22:53:22Z: INFO: push job for target <cdn_docker_stage> is COMPLETE
2023-10-13T22:53:22Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:53:22Z: INFO: advisory 121859 has dependent advisory [121862, 121860, 121861]
^@2023-10-13T22:54:12Z: INFO: checking push job status for advisory 121862 ...
2023-10-13T22:54:14Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:14Z: INFO: checking push job status for advisory 121860 ...
2023-10-13T22:54:16Z: INFO: push job for target <cdn_docker_stage> is COMPLETE
2023-10-13T22:54:16Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:16Z: INFO: checking push job status for advisory 121861 ...
2023-10-13T22:54:18Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:18Z: INFO: checking push job status for advisory 121859 ...
2023-10-13T22:54:20Z: INFO: push job for target <cdn_docker_stage> is COMPLETE
2023-10-13T22:54:20Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:20Z: INFO: advisory 121860 has dependent advisory []
2023-10-13T22:54:20Z: INFO: checking push job status for advisory 121860 ...
2023-10-13T22:54:22Z: INFO: push job for target <cdn_docker_stage> is COMPLETE
2023-10-13T22:54:22Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:22Z: INFO: advisory 121861 has dependent advisory []
2023-10-13T22:54:22Z: INFO: checking push job status for advisory 121861 ...
2023-10-13T22:54:24Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:24Z: INFO: advisory 121862 has dependent advisory [121861]
2023-10-13T22:54:34Z: INFO: checking push job status for advisory 121861 ...
2023-10-13T22:54:37Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:37Z: INFO: checking push job status for advisory 121862 ...
2023-10-13T22:54:39Z: INFO: push job for target <cdn_stage> is COMPLETE
2023-10-13T22:54:40Z: INFO: task [Pushing to CDN staging] status is changed to [Pass]
```

