### PR TITLE
OCPQE-17759 fix get advisory issue on 4.12

### DIFF
--- a/oar/core/config_store.py
+++ b/oar/core/config_store.py
@@ -305,7 +305,8 @@ class ConfigStore:
         """
         attr_val = None
         basis = self._assembly["basis"]
-        parent_assembly = self._get_value_by_path(self._build_data["releases"], f"{basis['assembly']}/assembly")
+        if "assembly" in basis:
+            parent_assembly = self._get_value_by_path(self._build_data["releases"], f"{basis['assembly']}/assembly")
         child_keypath = "%s!" % keypath
         
         attr_val = self._get_value_by_path(self._assembly, child_keypath)

--- a/oar/core/notification_mgr.py
+++ b/oar/core/notification_mgr.py
@@ -376,10 +376,12 @@ class MessageHelper:
         message += "Updated jira subtasks:\n"
         for key in updated_subtasks:
             message += self._to_link(util.get_jira_link(key), key) + " "
-        message += "\n"
-        message += "Found some abnormal advisories that state is not QE\n"
-        for ad in abnormal_ads:
-            message += self._to_link(util.get_advisory_link(ad), ad) + " "
+            
+        if len(abnormal_ads):
+            message += "\n"
+            message += "Found some abnormal advisories that state is not QE\n"
+            for ad in abnormal_ads:
+                message += self._to_link(util.get_advisory_link(ad), ad) + " "
 
         return message
 


### PR DESCRIPTION
this issue is introduced by [OCPQE-17717](https://issues.redhat.com/browse/OCPQE-17717), in 4.12 build data, it does not have parent assembly defined. so no inherited assembly. in OAR CLI code, we need to add this json key check, thanks for reporting this
