### PR TITLE
OCPQE-17886 change log level to info for test status

### DIFF
--- a/oar/core/advisory_mgr.py
+++ b/oar/core/advisory_mgr.py
@@ -98,6 +98,7 @@ class AdvisoryManager:
             []test: abnormal test list
         """
         abnormal_tests = []
+        valid_status = [CVP_TEST_STATUS_PASSED, CVP_TEST_STATUS_WAIVED]
         try:
             ads = self.get_advisories()
             for ad in ads:
@@ -109,10 +110,8 @@ class AdvisoryManager:
                 if len(tests):
                     for t in tests:
                         status = t["attributes"]["status"]
-                        logger.debug(
+                        logger.info(
                             f"Greenwave CVP test {t['id']} status is {status}")
-                        valid_status = [CVP_TEST_STATUS_PASSED,
-                                        CVP_TEST_STATUS_WAIVED]
                         if status not in valid_status:
                             all_passed = False
                             logger.error(


### PR DESCRIPTION
when checking greenwave cvp test result. cmd does not output the test status, just mentioned that the test status is invalid. in current logic we only output test status with debug level, it needs to be changed to info level