### PR TITLE
OCPQE-17982 update pkg dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
     "jira >= 3.4.1",
     "python-jenkins",
     "beautifulsoup4",
-    "rh-elliott@git+https://github.com/openshift-eng/elliott.git",
+    "pip-system-certs",
+    "artcommon@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=artcommon",
+    "rh-elliott@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=elliott",
     "lxml"
 ]
 


### PR DESCRIPTION
- install pkg pip-system-certs to replace ssl cert management pkg certifi. we will use system default trust ca bundle for SSL certification
- update rh-elliott pkg url due to ART team moved all the tools to new repo