### PR TITLE
OCPQE-17313 fix blocking advisory issue

### DIFF
--- a/oar/cli/cmd_push_to_cdn.py
+++ b/oar/cli/cmd_push_to_cdn.py
@@ -24,8 +24,8 @@ def push_to_cdn_staging(ctx):
         # update task status to in progress
         report.update_task_status(LABEL_TASK_PUSH_TO_CDN, TASK_STATUS_INPROGRESS)
         # trigger push job for cdn stage targets
-        job_triggered = am.push_to_cdn_staging()
-        if not job_triggered:
+        all_triggered = am.push_to_cdn_staging()
+        if all_triggered:
             report.update_task_status(LABEL_TASK_PUSH_TO_CDN, TASK_STATUS_PASS)
     except Exception as e:
         logger.exception("push to cdn staging failed")


### PR DESCRIPTION
- previous PR https://github.com/openshift/release-tests/pull/102 does not have the correct fix.

## submit new PR to fix AD dependency issue like following
- get AD dependency with errata attribute `blocking_advisories`, not `dependent_advisories`
- cache the push job info, avoid to call this api frequently
- add helper functions to check push job state, e.g. `are_push_jobs_running`, `are_push_jobs_completed` and `has_failed_push_job`
- if one AD has blocking ADs, trigger pub job for them anyway. then check the job state, if any of them is not completed, log warn message to ask user try again later, because only push jobs of  blocking ADs are all completed, then we can trigger push job for current AD. 
- if all push jobs are triggered for all the ADs, mark the task status in report to pass
- to trigger push to CDN jobs for all the ADs, we need to run this cmd multiple times.