### PR TITLE
OCPQE-18416 refine logic of push to cdn staging

### DIFF
--- a/oar/cli/cmd_push_to_cdn.py
+++ b/oar/cli/cmd_push_to_cdn.py
@@ -24,8 +24,9 @@ def push_to_cdn_staging(ctx):
         # update task status to in progress
         report.update_task_status(LABEL_TASK_PUSH_TO_CDN, TASK_STATUS_INPROGRESS)
         # trigger push job for cdn stage targets
-        all_triggered = am.push_to_cdn_staging()
-        if all_triggered:
+        # only mark the task to pass when all jobs are completed
+        all_jobs_completed = am.push_to_cdn_staging()
+        if all_jobs_completed:
             report.update_task_status(LABEL_TASK_PUSH_TO_CDN, TASK_STATUS_PASS)
     except Exception as e:
         logger.exception("push to cdn staging failed")


### PR DESCRIPTION
refine the logic of func `Advisory.push_to_cdn`, true means all jobs are completed. false means jobs are running or just triggered

- if all push jobs are completed, return true
- if any push job is running and there is no failed job, return false. i.e. action is in progress
- if no jobs are triggered or there is any failed job found (retry), trigger the push job with target [stage]
- if any blocking advisory found, trigger push job for it
- if all the blocking jobs are completed, trigger push job for current advisory

/assign @ming1013 