### PR TITLE
update amd64 base image query for arm payload

### DIFF
--- a/prow/job/__init__.py
+++ b/prow/job/__init__.py
@@ -1,2 +1,2 @@
-version_info = (2, 1, 0)
+version_info = (2, 1, 1)
 version = '.'.join(str(c) for c in version_info)

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -40,11 +40,12 @@ class Jobs(object):
     # so extract the corresponding amd64 version from the arm64 build, 
     # see bug: https://issues.redhat.com/browse/DPTP-3538, https://issues.redhat.com/browse/OCPQE-17600
     def get_amdBaseImage_for_arm(self, payload):
-        versionPattern = re.compile(":(\d*\.\d{2}\.\d)-")
+        versionPattern = re.compile(":(\d*\.\d{2}\.\d)(-.*)?-")
         version = versionPattern.findall(payload)
         if len(version) > 0:
-            self.base_image = "quay.io/openshift-release-dev/ocp-release:%s-x86_64" % version[0]
-            print("Use amd64 base image: %s" % self.base_image)
+            version_string = "".join(version[0])
+            self.base_image = "quay.io/openshift-release-dev/ocp-release:%s-x86_64" % version_string
+            print("Infer the amd64 image: %s from arm payload: %s" % (self.base_image, payload))
         else:
             print("Warning! Fail to get the corresponding amd64 base image, use the default one:%s" % self.base_image)
 
@@ -85,12 +86,12 @@ class Jobs(object):
             if "ppc64le" in upgrade_from and "ppc64le" in upgrade_to:
                 env = {"envs": {ppc64le_latest: upgrade_from, ppc64le_target: upgrade_to}}
             # check if it's for ARM, and amd_latest env is must no mater what platforms you run
-            if "arm64" in upgrade_from or "aarch64" in upgrade_from:
-                self.get_amdBaseImage_for_arm(upgrade_from)
-                env = {"envs": {amd_latest: self.base_image, arm_latest: upgrade_from}}
-            if "arm64" in upgrade_to or "aarch64" in upgrade_to:
-                self.get_amdBaseImage_for_arm(upgrade_to)
-                env = {"envs": {amd_latest: self.base_image, arm_target: upgrade_to}}
+            # if "arm64" in upgrade_from or "aarch64" in upgrade_from:
+            #     self.get_amdBaseImage_for_arm(upgrade_from)
+            #     env = {"envs": {amd_latest: self.base_image, arm_latest: upgrade_from}}
+            # if "arm64" in upgrade_to or "aarch64" in upgrade_to:
+            #     self.get_amdBaseImage_for_arm(upgrade_to)
+            #     env = {"envs": {amd_latest: self.base_image, arm_target: upgrade_to}}
             if ("arm64" in upgrade_from or "aarch64" in upgrade_from) and (
                 "arm64" in upgrade_to or "aarch64" in upgrade_to
             ):


### PR DESCRIPTION
Before, the job infer the amd64 image is `quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64`, it doesn't exist and lead `  * could not run steps: step [release:latest] failed: unable to import latest release image: timed out waiting for the condition `, details:  https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14/1739485263698071552 
```console
MacBook-Pro:~ jianzhang$ job run periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 --upgrade_from=quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64 --upgrade_to=registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321
Debug mode is off
Use amd64 base image: quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64
Use amd64 base image: quay.io/openshift-release-dev/ocp-release:4.16.0-x86_64
Use amd64 base image: quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64', 'RELEASE_IMAGE_ARM64_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64', 'RELEASE_IMAGE_ARM64_TARGET': 'registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321'}}}
Returned job id: 8d68a852-5f6b-4462-b801-7dc1c83c2ee5
periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 None 8d68a852-5f6b-4462-b801-7dc1c83c2ee5 2023-12-26T03:16:19Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14/1739485263698071552
Done.
```
After this PR, it can get the correct base image from the input. And, https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14/1739497502001860608 works well.
Supports

- payload1 = "quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64"
- payload2 = "quay.io/openshift-release-dev/ocp-release:4.15.0-ec.3-x86_64"
- payload3 = "quay.io/openshift-release-dev/ocp-release:4.14.7-x86_64"

```
MacBook-Pro:~ jianzhang$ job run periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 --upgrade_from=quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64 --upgrade_to=registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321
Debug mode is off
infer the amd64 image: quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-x86_64 from arm payload: quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-x86_64', 'RELEASE_IMAGE_ARM64_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64', 'RELEASE_IMAGE_ARM64_TARGET': 'registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321'}}}
Returned job id: 38166138-6f13-4f42-a648-60a0e4a0efcf
periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 None 38166138-6f13-4f42-a648-60a0e4a0efcf 2023-12-26T04:04:57Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14/1739497502001860608
Done.
```
And, I comment some code since the upgrading doesn't support different arches, such as, from **amd64-4.14** upgrade to **arm64-4.15**.