### PR TITLE
add run_z_stream_test command

### DIFF
--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -33,7 +33,7 @@ class Jobs(object):
             headers = {"Authorization": "Bearer " + token.strip()}
             return headers
         else:
-            print("No Prow API token found, exit...")
+            print("No APITOKEN env var found, exit...")
             sys.exit(0)
 
     # it's for ARM test, now unable to find the 'cli' image in the provided ARM release image, but x86
@@ -281,11 +281,11 @@ class Jobs(object):
             headers = {"Authorization": "Bearer " + token.strip()}
             return headers
         else:
-            print("No GITHUB_TOKEN found, exit...")
+            print("No GITHUB_TOKEN env var found, exit...")
             sys.exit(0)
 
     def get_required_jobs(self, file_path):
-        print("use file: %s" % file_path)
+        print("use JSON file: %s" % file_path)
         if file_path is None:
             return None
         with open(file_path) as f:
@@ -475,9 +475,61 @@ class Jobs(object):
         except Exception as e:
             print(e)
 
+    def run_z_stream_test(self):
+        # get required OCP version info and jobs from JSON file
+        """
+        { 
+            "4.10" : [
+                    "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28",
+                    "periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28",
+                    ...
+                    ],
+            "4.11" : [...],
+            ...
+        """
+        # get the payload info
+        res = requests.get(url=self.url, timeout=5)
+        if res.status_code != 200:
+            print("Fail to get payload info, %s:%s" % (res.status_code, res.reason))
+            sys.exit(1)
+        dict = json.loads(res.text)
+        # get the job info from a JSON file
+        job_dict = self.get_required_jobs("_releases/required-jobs.json")
+        for y_version, jobs in job_dict.items():
+            # z_version is like "4.10.0", and y_version is like "4.10"
+            print("getting the latest payload of %s" % y_version)
+            latest_version = ""
+            for tag in dict["tags"]:
+                if tag["phase"] == "Accepted":
+                    new = VersionInfo.parse(tag["name"])
+                    old = VersionInfo.parse(y_version+".0")
+                    if new >= old:
+                        if new.minor == old.minor:
+                            print("The latest version of %s is: %s" % (y_version, tag["name"]))
+                            latest_version = tag["name"]
+                            self.push_versions(content=latest_version, file="Auto-OCP-%s.txt" % y_version, run=False)
+                            break
+            else:
+                # if no break, that means no new version found, so continue
+                continue
+            for job in jobs:
+                print("Run job: %s" % job)
+                # amd64 as default
+                payload = "quay.io/openshift-release-dev/ocp-release:{}-x86_64".format(latest_version)
+                if "arm64" in job:
+                    payload = "quay.io/openshift-release-dev/ocp-release:{}-aarch64".format(latest_version)
+                # specify the latest stable payload for upgrade test
+                if "upgrade-from-stable" in job:
+                    self.run_job(job, None, None, upgrade_to=payload)
+                # specify the latest stable payload for e2e test
+                elif "upgrade" not in job:
+                    self.run_job(job, payload, None, None)
+                # as default
+                else:
+                    self.run_job(job, None, None, None)
+
 
 job = Jobs()
-
 
 @click.group()
 @click.version_option(package_name="job")
@@ -554,6 +606,12 @@ def run_payloads(versions, push, run):
     """Check the latest stable payload of each version. Use comma spacing if multi versions, such as, 4.10.0,4.11.0,4.12.0"""
     job.get_payloads(versions, push, run)
 
+@cli.command("run_z_stream_test")
+def run_cmd():
+    """Run jobs list in the _releases/required-jobs.json file.
+     It only used for periodic-ci-openshift-release-tests-master-stable-build-test prow job.
+    """
+    job.run_z_stream_test()
 
 if __name__ == "__main__":
     start = time.time()


### PR DESCRIPTION
As title, 
```console
MacBook-Pro:release-tests jianzhang$ job run_z_stream_test
Debug mode is off
use JSON file: _releases/required-jobs.json
getting the latest payload of 4.10
The latest version of 4.10 is: 4.10.67
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-aws-ipi-ovn-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-azure-ipi-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-gcp-ipi-proxy-private-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-vsphere-ipi-proxy-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-arm64-stable-aws-ipi-ovn-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-stable-4.10-upgrade-from-eus-4.8-aws-ipi-ovn-p2-f30
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.9-aws-ipi-byo-kms-etcd-encryption-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.10-amd64-nightly-4.10-upgrade-from-stable-4.10-azure-ipi-fips-p2-f1
getting the latest payload of 4.11
The latest version of 4.11 is: 4.11.55
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-aws-c2s-ipi-disconnected-private-fips-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-azure-ipi-disconnected-fullyprivate-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-gcp-ipi-proxy-private-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-stable-vsphere-ipi-proxy-fips-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-arm64-stable-aws-ipi-ovn-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.10-azure-ipi-workers-rhel8-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.11-amd64-nightly-4.11-upgrade-from-stable-4.11-vsphere-ipi-proxy-fips-p2-f360
getting the latest payload of 4.12
The latest version of 4.12 is: 4.12.46
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-ipi-ovn-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-vsphere-ipi-proxy-workers-rhel8-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-aws-rosa-sts-hypershift-guest-integration-critical-p1-f2
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-azure-ipi-disconnected-fullyprivate-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-multi-nightly-aws-ipi-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-stable-4.12-upgrade-from-stable-4.11-aws-ipi-ovn-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.12-amd64-nightly-4.12-upgrade-from-stable-4.12-vsphere-upi-p3-f28
getting the latest payload of 4.13
The latest version of 4.13 is: 4.13.27
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-vsphere-ipi-proxy-fips-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-nutanix-ipi-proxy-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-ibmcloud-ipi-private-fips-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-azure-ipi-baselinecaps-v412-to-multiarch-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-aws-rosa-sts-p2-f7
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-nightly-azure-ipi-disconnected-fullyprivate-tp-p3-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-aws-ipi-ovn-ipsec-to-multiarch-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-baremetal-upi-to-multiarch-p2-f7
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-stable-4.13-upgrade-from-stable-4.12-gcp-ipi-proxy-private-p2-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-arm64-stable-4.13-upgrade-from-stable-4.12-azure-ipi-fullyprivate-proxy-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-ovn-fips-p2-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.13-amd64-nightly-4.13-upgrade-from-stable-4.13-aws-ipi-byo-iam-role-cert-rotation-p2-f14
getting the latest payload of 4.14
The latest version of 4.14 is: 4.14.7
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-eus-4.12-ibmcloud-ipi-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-aws-ipi-disconnected-sts-basecap-none-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-azure-ipi-proxy-workers-rhcos-rhel8-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-baremetalds-ipi-ovn-ipv4-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-gcp-ipi-confidential-computing-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-nutanix-ipi-boot-categories-project-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.13-vsphere-ipi-compact-etcd-encryption-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-aws-ipi-ovn-hypershift-inplace-f7
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-azure-ipi-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-gcp-ipi-ovn-ipsec-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-ibmcloud-ipi-private-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-nutanix-ipi-proxy-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-4.14-upgrade-from-stable-4.14-vsphere-ipi-ovn-ipsec-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-alibaba-ipi-private-fips-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-aws-ipi-disconnected-private-sno-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-azure-ipi-marketplace-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-baremetal-ha-agent-ipv4-static-disconnected-f7
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-gcp-ipi-marketplace-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-ibmcloud-ipi-ovn-ipsec-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-nutanix-ipi-compact-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-amd64-nightly-vsphere-8-agent-compact-f14
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-arm64-nightly-4.14-upgrade-from-eus-4.12-aws-ipi-ovn-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-arm64-nightly-4.14-upgrade-from-eus-4.12-azure-ipi-f28
Run job: periodic-ci-openshift-openshift-tests-private-release-4.14-arm64-nightly-4.14-upgrade-from-stable-4.13-aws-ipi-disconnected-sts-f28
getting the latest payload of 4.15
getting the latest payload of 4.16
```