### PR TITLE
add 1s sleep for job startup

### DIFF
--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -344,6 +344,8 @@ class Jobs(object):
                 # print(res.text)
                 job_id = json.loads(res.text)["id"]
                 print("Returned job id: %s" % job_id)
+                # wait 1s for the job startup
+                time.sleep(1)
                 self.get_job_results(job_id, jobName, payload, upgrade_from, upgrade_to)
             else:
                 print("Error code: %s, reason: %s" % (res.status_code, res.reason))


### PR DESCRIPTION
It couldn't get the job results immediately once the job triggered sometimes, 
```console
Run job: periodic-ci-openshift-openshift-tests-private-release-4.9-sanity
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.9.59-x86_64'}}}
Returned job id: 22114ef1-411e-41d3-8399-8c5c3fe07eda
Not found the url link or creationTimestamp...
```
But, it did run, so add `1s` sleep.
```console
MacBook-Pro:release-tests jianzhang$ job get_results 22114ef1-411e-41d3-8399-8c5c3fe07eda
Debug mode is off
None None 22114ef1-411e-41d3-8399-8c5c3fe07eda 2024-01-05T07:07:07Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.9-sanity/1743167225663066112
```