### PR TITLE
use go1.21 for k8sgpt

### DIFF
--- a/prow/Dockerfile.k8sgpt
+++ b/prow/Dockerfile.k8sgpt
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16
 LABEL maintainer="jiazha@redhat.com"
 WORKDIR /go/src/github.com/k8sgpt-ai
 RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git && \


### PR DESCRIPTION
Address https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release-tests/128/pull-ci-openshift-release-tests-master-images/1746807193346248704
```console
vendor/github.com/pterm/pterm/slog_handler.go:6:2: package log/slog is not in GOROOT (/usr/lib/golang/src/log/slog)
note: imported by a module that requires go 1.21
make: *** [Makefile:57: build] Error 1
error: build error: building at STEP "RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git &&     cd k8sgpt &&     go mod vendor &&     make build": while running runtime: exit status 2
```