### PR TITLE
update error handles

### DIFF
--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -41,7 +41,7 @@ class Jobs(object):
     # so extract the corresponding amd64 version from the arm64 build, 
     # see bug: https://issues.redhat.com/browse/DPTP-3538, https://issues.redhat.com/browse/OCPQE-17600
     def get_amdBaseImage_for_arm(self, payload):
-        versionPattern = re.compile(":(\d*\.\d{2}\.\d)(-.*)?-")
+        versionPattern = re.compile(r':(\d*\.\d{2}\.\d)(-.*)?-')
         version = versionPattern.findall(payload)
         if len(version) > 0:
             version_string = "".join(version[0])
@@ -395,9 +395,7 @@ class Jobs(object):
                             else:
                                 return job_dict
 
-    def get_job_results(
-        self, jobID, jobName=None, payload=None, upgrade_from=None, upgrade_to=None
-    ):
+    def get_job_results(self, jobID, jobName=None, payload=None, upgrade_from=None, upgrade_to=None):
         if jobID:
             req = requests.get(url=self.prowJobURL.format(jobID.strip()))
             if req.status_code == 200:
@@ -426,9 +424,7 @@ class Jobs(object):
                 else:
                     print("Not found the url link or creationTimestamp...")
             else:
-                raise Exception(
-                    "return status code:%s reason:%s" % (req.status_code, req.reason)
-                )
+                print("return status code:%s reason:%s" % (req.status_code, req.reason))
         else:
             print("No job ID input, exit...")
             sys.exit(0)


### PR DESCRIPTION
Remove the `Exception`.
```python
jiazha-mac:~ jiazha$ job get_results 1747152353489850368
Debug mode is off
Traceback (most recent call last):
  File "/opt/homebrew/bin/job", line 33, in <module>
    sys.exit(load_entry_point('job', 'console_scripts', 'job')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.12/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jiazha/goproject/release-tests/prow/job/job.py", line 555, in get_cmd
    job.get_job_results(job_id)
  File "/Users/jiazha/goproject/release-tests/prow/job/job.py", line 429, in get_job_results
    raise Exception(
Exception: return status code:404 reason:Not Found
```
And fix re
```python
jiazha-mac:~ jiazha$ job get_results 1747152353489850368
/Users/jiazha/goproject/release-tests/prow/job/job.py:44: SyntaxWarning: invalid escape sequence '\d'
  versionPattern = re.compile(":(\d*\.\d{2}\.\d)(-.*)?-")
Debug mode is off
return status code:404 reason:Not Found
```
And, it works well.
```python
jiazha-mac:~ jiazha$ job get_results 1747152353489850368
Debug mode is off
return status code:404 reason:Not Found

jiazha-mac:~ jiazha$ job run periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 --upgrade_from=quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64 --upgrade_to=registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321
Debug mode is off
Infer the amd64 image: quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-x86_64 from arm payload: quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-x86_64', 'RELEASE_IMAGE_ARM64_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.15.0-rc.0-aarch64', 'RELEASE_IMAGE_ARM64_TARGET': 'registry.ci.openshift.org/ocp-arm64/release-arm64:4.16.0-0.nightly-arm64-2023-12-21-021321'}}}
Returned job id: 9e7d6c93-8fda-4e0e-a840-dd55b685641e
periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14 None 9e7d6c93-8fda-4e0e-a840-dd55b685641e 2024-01-16T07:28:48Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-arm64-nightly-4.16-upgrade-from-stable-4.15-azure-ipi-ovn-ipsec-f14/1747158949364240384
Done.
```