### PR TITLE
OCPQE-19030 support ec build for latest release

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -37,19 +37,21 @@ class JobController:
                 url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/{self._release}.0-0.nightly/latest"
             else:
                 url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest?prefix={self._release}"
+                if requests.get(url).status_code == 404: # if latest stable build is valid and not found, i.e. 4.16, we check releasestream 4-dev-preview instead
+                    url = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-dev-preview/latest"
 
             logger.info(f"Getting latest {self._build_type} build for {self._release} ...")
             resp = requests.get(url)
             resp.raise_for_status()
-        except RequestException as re:
+        except RequestException as re: 
             logger.error(f"Get latest  {self._build_type} build error {re}")
             raise
 
         if resp.text:
             logger.info(f"Latest  {self._build_type} build of {self._release} is:\n{resp.text}")
             # if record file does not exist, create it on github repo
-            if not self.release_test_record.file_exists(self._build_file_for_nightly):
-                self.release_test_record.push_file(data=resp.text, path=self._build_file_for_nightly)
+            if not self.release_test_record.file_exists(self._build_file):
+                self.release_test_record.push_file(data=resp.text, path=self._build_file)
             
         return Build(resp.text)
     

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -43,7 +43,7 @@ class JobController:
             logger.info(f"Getting latest {self._build_type} build for {self._release} ...")
             resp = requests.get(url)
             resp.raise_for_status()
-        except RequestException as re: 
+        except RequestException as re:
             logger.error(f"Get latest  {self._build_type} build error {re}")
             raise
 


### PR DESCRIPTION
if build is valid and cannot find latest stable build from stream `4-stable` e.g. `4.16`, we check `4-dev-preview` release stream instead.

```console
$ jobctl start-controller -r 4.16 --no-nightly --trigger-prow-job false
2024-02-02T17:48:43Z: INFO: Getting latest stable build for 4.16 ...
2024-02-02T17:48:44Z: INFO: Latest  stable build of 4.16 is:
{
  "name": "4.16.0-ec.1",
  "phase": "Accepted",
  "pullSpec": "quay.io/openshift-release-dev/ocp-release:4.16.0-ec.1-x86_64",
  "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.16.0-ec.1"
}

2024-02-02T17:48:45Z: INFO: File _releases/ocp-latest-4.16-stable.json not found
2024-02-02T17:48:45Z: INFO: File _releases/ocp-latest-4.16-stable.json not found
2024-02-02T17:48:45Z: INFO: Creating file _releases/ocp-latest-4.16-stable.json
2024-02-02T17:48:46Z: INFO: File is created successfully
2024-02-02T17:48:47Z: INFO: Current build is same as latest build 4.16.0-ec.1, no diff found
```