### PR TITLE
OCPQE-19030 test result aggregator and related flow

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -336,8 +336,6 @@ class TestResultAggregator():
                 
                 if qe_accepted:
                     self.update_releasepayload()
-                else:
-                    logger.info(f"Not all the required jobs of build {build} are completed and success")
                     
     def update_releasepayload(self):
         pass

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -31,7 +31,7 @@ class JobController:
         self._build_file_for_nightly = f"{DIR_RELEASE}/ocp-latest-{self._release}-nightly.json"
         self._build_file_for_stable = f"{DIR_RELEASE}/ocp-latest-{self._release}-stable.json"
         self._build_file = self._build_file_for_nightly if self._nightly else self._build_file_for_stable
-        validate_required_info()
+        validate_required_info(release)
         self.job_api = Jobs()
         self.job_registry = TestJobRegistry()
         self.release_test_record = GithubUtil(REPO_RELEASE_TESTS, BRANCH_RECORD)


### PR DESCRIPTION
- when new build is found job controller will trigger the prow job and save the job name/id on github branch `record` 
```console
$ jobctl start-controller -r 4.16 --nightly
```
- run test result aggregator to scan all the test result files like `_releases/ocp-test-result-$build.json`, check all the prow jobs' state, skip the optional job, if `required-job-count == success-job-count`, update releasepayload, updated test result is like https://github.com/openshift/release-tests/blob/record/_releases/ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json

```console
$ jobctl start-aggregator
2024-02-04T21:45:33Z: INFO: Initializing test job registry ...
2024-02-04T21:45:35Z: INFO: Test job definitions for 4.16 is initialized
2024-02-04T21:45:35Z: INFO: Test job registry is initialized
2024-02-04T21:45:38Z: INFO: Start to scan test result files ...
2024-02-04T21:45:39Z: INFO: Found test result file ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json
2024-02-04T21:45:40Z: INFO: Start to check test result for 4.16.0-0.nightly-2024-02-03-221256 ...
periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-f14 None 5c9acd57-873c-47e9-8e99-19702d557556 2024-02-04T11:47:59Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-f14/1754109544331481088 pending
Done.

periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-4.16-upgrade-from-stable-4.15-aws-ipi-disconnected-sts-basecap-none-f28 None 11f63908-90cd-4f49-b11c-83b8d6239fbd 2024-02-04T11:48:03Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-4.16-upgrade-from-stable-4.15-aws-ipi-disconnected-sts-basecap-none-f28/1754109559170928640 pending
Done.

2024-02-04T21:45:46Z: INFO: File _releases/ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json can be found
2024-02-04T21:45:47Z: INFO: Updating file _releases/ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json
2024-02-04T21:45:48Z: INFO: File is updated successfully
2024-02-04T21:45:48Z: INFO: Latest test result of 4.16.0-0.nightly-2024-02-03-221256 is updated to file _releases/ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json
2024-02-04T21:45:48Z: INFO: Test result summary of 4.16.0-0.nightly-2024-02-03-221256: all:2, required:1, completed:0, success:0, failed:0, pending:2, qe_accepted:false
2024-02-04T21:45:48Z: INFO: Not all the required jobs of build 4.16.0-0.nightly-2024-02-03-221256 are completed and success
```