### PR TITLE
OCPQE-19030 fix aggregator issue

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -24,10 +24,12 @@ SYS_ENV_VAR_API_TOKEN = "APITOKEN"
 VALID_RELEASES = ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
 RELEASE_STREAM_BASE_URL = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream"
 
+
 class JobController:
 
     def __init__(self, release, nightly=True, trigger_prow_job=True):
-        self._release = release[:-2] if len(release.split("."))==3 else release
+        self._release = release[:-
+                                2] if len(release.split(".")) == 3 else release
         self._nightly = nightly
         self._trigger_prow_job = trigger_prow_job
         self._build_type = 'nightly' if self._nightly else 'stable'
@@ -37,9 +39,10 @@ class JobController:
         validate_required_info(release)
         self.job_api = Jobs()
         self.job_registry = TestJobRegistry()
-        self.release_test_record = GithubUtil(REPO_RELEASE_TESTS, BRANCH_RECORD)
+        self.release_test_record = GithubUtil(
+            REPO_RELEASE_TESTS, BRANCH_RECORD)
         self.release_test_master = GithubUtil(REPO_RELEASE_TESTS)
-        
+
     def get_latest_build(self):
 
         try:
@@ -47,10 +50,12 @@ class JobController:
                 url = f"{RELEASE_STREAM_BASE_URL}/{self._release}.0-0.nightly/latest"
             else:
                 url = f"{RELEASE_STREAM_BASE_URL}/4-stable/latest?prefix={self._release}"
-                if requests.get(url).status_code == 404: # if latest stable build is valid and not found, i.e. 4.16, we check releasestream 4-dev-preview instead
+                # if latest stable build is valid and not found, i.e. 4.16, we check releasestream 4-dev-preview instead
+                if requests.get(url).status_code == 404:
                     url = f"{RELEASE_STREAM_BASE_URL}/4-dev-preview/latest"
 
-            logger.info(f"Getting latest {self._build_type} build for {self._release} ...")
+            logger.info(
+                f"Getting latest {self._build_type} build for {self._release} ...")
             resp = requests.get(url)
             resp.raise_for_status()
         except RequestException as re:
@@ -58,69 +63,82 @@ class JobController:
             raise
 
         if resp.text:
-            logger.info(f"Latest  {self._build_type} build of {self._release} is:\n{resp.text}")
+            logger.info(
+                f"Latest  {self._build_type} build of {self._release} is:\n{resp.text}")
             # if record file does not exist, create it on github repo
             if not self.release_test_record.file_exists(self._build_file):
-                self.release_test_record.push_file(data=resp.text, path=self._build_file)
-            
+                self.release_test_record.push_file(
+                    data=resp.text, path=self._build_file)
+
         return Build(resp.text)
-    
+
     def get_current_build(self):
         data = self.release_test_record.get_file_content(self._build_file)
         return Build(data)
-    
+
     def update_current_build(self, build):
         if build.raw_data:
-            self.release_test_record.push_file(build.raw_data, self._build_file)
+            self.release_test_record.push_file(
+                build.raw_data, self._build_file)
 
         logger.info(f"current build info is updated on repo")
 
     def trigger_prow_jobs(self, build):
 
-        test_jobs = self.job_registry.get_test_jobs(self._release, self._nightly)
+        test_jobs = self.job_registry.get_test_jobs(
+            self._release, self._nightly)
         test_result = []
         if len(test_jobs):
             for test_job in test_jobs:
                 if test_job.disabled:
-                    logger.info(f"Won't trigger prow job {test_job}, it is disabled")
+                    logger.info(
+                        f"Won't trigger prow job {test_job}, it is disabled")
                     continue
-      
-                logger.info(f"Start to trigger prow job {test_job.prow_job} ...\n")        
+
+                logger.info(
+                    f"Start to trigger prow job {test_job.prow_job} ...\n")
                 if test_job.upgrade:
-                    prow_job_id = self.job_api.run_job(job_name=test_job.prow_job, upgrade_to=build.pull_spec, upgrade_from=None, payload=None)
+                    prow_job_id = self.job_api.run_job(
+                        job_name=test_job.prow_job, upgrade_to=build.pull_spec, upgrade_from=None, payload=None)
                 else:
-                    prow_job_id = self.job_api.run_job(job_name=test_job.prow_job, payload=build.pull_spec, upgrade_from=None, upgrade_to=None)
-                logger.info(f"Triggered prow job {test_job.prow_job} with build {build.name}, job id={prow_job_id}\n")
-                
+                    prow_job_id = self.job_api.run_job(
+                        job_name=test_job.prow_job, payload=build.pull_spec, upgrade_from=None, upgrade_to=None)
+                logger.info(
+                    f"Triggered prow job {test_job.prow_job} with build {build.name}, job id={prow_job_id}\n")
+
                 job_item = {}
                 if prow_job_id:
                     job_item["jobName"] = test_job.prow_job
                     job_item["jobID"] = prow_job_id
                     test_result.append(job_item)
                 else:
-                    logger.error(f"Trigger prow job {test_job.prow_job} with build {build.name} failed, no prow job id returned")
+                    logger.error(
+                        f"Trigger prow job {test_job.prow_job} with build {build.name} failed, no prow job id returned")
 
             if len(test_result):
                 data = json.dumps({build.name: test_result}, indent=2)
                 logger.debug(f"Test result file content {data}")
                 file_path = f"{DIR_RELEASE}/ocp-test-result-{build.name}.json"
                 self.release_test_record.push_file(data=data, path=file_path)
-                logger.info(f"Test result of {build.name} is saved to {file_path}")
-        
+                logger.info(
+                    f"Test result of {build.name} is saved to {file_path}")
+
     def start(self):
         # get latest build info
         latest = self.get_latest_build()
         current = self.get_current_build()
         # compare whether current = latest, if latest is newer than current trigger prow jobs
         if latest.equals(current):
-            logger.info(f"Current build is same as latest build {latest.name}, no diff found")
+            logger.info(
+                f"Current build is same as latest build {latest.name}, no diff found")
         else:
             logger.info(f"Found new build {latest.name}")
             self.update_current_build(latest)
             if self._trigger_prow_job:
                 self.trigger_prow_jobs(latest)
             else:
-                logger.warning("Won't trigger prow jobs since control flag [--trigger-prow-job] is false")
+                logger.warning(
+                    "Won't trigger prow jobs since control flag [--trigger-prow-job] is false")
 
 
 class Build():
@@ -132,7 +150,7 @@ class Build():
     @property
     def name(self):
         return self._json_data["name"]
-    
+
     @property
     def phase(self):
         return self._json_data["phase"]
@@ -140,21 +158,22 @@ class Build():
     @property
     def pull_spec(self):
         return self._json_data["pullSpec"]
-    
+
     @property
     def download_url(self):
         return self._json_data["downloadURL"]
-    
+
     @property
     def raw_data(self):
         return self._raw_data
-    
+
     def equals(self, build):
         if isinstance(build, Build):
             return self.name == build.name
-        
+
         return False
-    
+
+
 class TestJob():
 
     def __init__(self, data):
@@ -163,22 +182,22 @@ class TestJob():
     @property
     def prow_job(self):
         return self._json_data["prowJob"]
-    
+
     @property
     def disabled(self):
         # default value is false
         return bool(self._json_data["disabled"]) if "disabled" in self._json_data else False
-    
+
     @property
     def upgrade(self):
         # default value is false
         return bool(self._json_data["upgrade"]) if "upgrade" in self._json_data else False
-    
+
     @property
     def optional(self):
         # default value is false
         return bool(self._json_data["optional"]) if "optional" in self._json_data else False
-    
+
 
 class GithubUtil:
 
@@ -209,12 +228,14 @@ class GithubUtil:
 
     def get_files(self, path):
         return self._repo.get_contents(path=path, ref=self._branch)
-            
+
     def get_file_content(self, path):
         content = self._repo.get_contents(path=path, ref=self._branch)
-        logger.debug(f"file content of {content.path} is:\n{content.decoded_content.decode('utf-8')}")
-        return content.decoded_content.decode("utf-8")
-        
+        decoded_content = content.decoded_content.decode('utf-8')
+        logger.debug(
+            f"file content of {content.path} is:\n{decoded_content}")
+        return
+
     def file_exists(self, path):
         try:
             self._repo.get_contents(path=path, ref=self._branch)
@@ -222,9 +243,9 @@ class GithubUtil:
         except UnknownObjectException:
             logger.info(f"File {path} not found")
             return False
-        
+
         return True
-    
+
     def delete_file(self, path):
         if self.file_exists(path):
             content = self._repo.get_contents(path=path, ref=self._branch)
@@ -237,6 +258,7 @@ class GithubUtil:
         else:
             logger.info(f"File {path} not found")
 
+
 class TestJobRegistry():
 
     def __init__(self):
@@ -246,19 +268,21 @@ class TestJobRegistry():
 
     def init(self):
         logger.info("Initializing test job registry ...")
-        
+
         contents = self.release_tests_master.get_files(DIR_RELEASE)
         for content in contents:
-                matched_path = re.search(r'ocp-\d\.\d+-test-jobs.json', content.path)
-                if matched_path:
-                    release = re.search(r'\d\.\d+', matched_path.group()).group()
-                    file_content = self.release_tests_master.get_file_content(content.path)
-                    self._registry[release] = json.loads(file_content)
-                    logger.info(f"Test job definitions for {release} is initialized")
-        
+            matched_path = re.search(
+                r'ocp-\d\.\d+-test-jobs.json', content.path)
+            if matched_path:
+                release = re.search(r'\d\.\d+', matched_path.group()).group()
+                file_content = self.release_tests_master.get_file_content(
+                    content.path)
+                self._registry[release] = json.loads(file_content)
+                logger.info(
+                    f"Test job definitions for {release} is initialized")
+
         logger.info("Test job registry is initialized")
-                    
-                    
+
     def get_test_jobs(self, release, nightly):
 
         test_jobs = []
@@ -270,21 +294,24 @@ class TestJobRegistry():
                 test_jobs.append(TestJob(job))
 
         return test_jobs
-    
+
     def get_test_job(self, release, nightly, job_name):
         jobs = self.get_test_jobs(release, nightly)
         filtered_jobs = [j for j in jobs if j.prow_job == job_name]
         if len(filtered_jobs):
             return filtered_jobs[0]
         else:
-            logger.info(f"Cannot find test job {job_name} in {release} definition")
+            logger.info(
+                f"Cannot find test job {job_name} in {release} definition")
+
 
 class TestResultAggregator():
-    
+
     def __init__(self):
         validate_required_info()
         self.job_registry = TestJobRegistry()
-        self.release_test_record = GithubUtil(REPO_RELEASE_TESTS, BRANCH_RECORD)
+        self.release_test_record = GithubUtil(
+            REPO_RELEASE_TESTS, BRANCH_RECORD)
         self.job_api = Jobs()
 
     def start(self):
@@ -296,7 +323,8 @@ class TestResultAggregator():
                 logger.info(f"Found test result file {matched_path.group()}")
                 release = re.search(r"\d\.\d+", matched_path.group()).group()
                 nightly = "nightly" in matched_path.group()
-                file_content = self.release_test_record.get_file_content(content.path)
+                file_content = self.release_test_record.get_file_content(
+                    content.path)
                 json_data = json.loads(file_content)
                 build = list(json_data.keys())[0]
                 logger.info(f"Start to check test result for {build} ...")
@@ -326,30 +354,38 @@ class TestResultAggregator():
                         completed_job_count += 1
                     else:
                         pending_job_count += 1
-                    job_meta = self.job_registry.get_test_job(release, nightly, job_name)
+                    job_meta = self.job_registry.get_test_job(
+                        release, nightly, job_name)
                     if not job_meta.optional:
-                       required_job_count += 1
-                    
-                self.release_test_record.push_file(data=json.dumps(json_data, indent=2), path=content.path)
-                logger.info(f"Latest test result of {build} is updated to file {content.path}")
+                        required_job_count += 1
+
+                self.release_test_record.push_file(
+                    data=json.dumps(json_data, indent=2), path=content.path)
+                logger.info(
+                    f"Latest test result of {build} is updated to file {content.path}")
 
                 # check if all the required jobs are success, if yes, update releasepayload with label release.openshift.io/qe_state=Accepted
                 qe_accepted = (required_job_count == success_job_count)
-                logger.info(f"Test result summary of {build}: all:{len(jobs)}, required:{required_job_count}, completed:{completed_job_count}, success:{success_job_count}, failed:{failed_job_count}, pending:{pending_job_count}, qe_accepted:{str(qe_accepted).lower()}")
-                
+                logger.info(
+                    f"Test result summary of {build}: all:{len(jobs)}, required:{required_job_count}, completed:{completed_job_count}, success:{success_job_count}, failed:{failed_job_count}, pending:{pending_job_count}, qe_accepted:{str(qe_accepted).lower()}")
+
                 if qe_accepted:
                     self.update_releasepayload()
-                    
+
     def update_releasepayload(self):
         pass
 
+
 def validate_required_info(release=None):
     if os.environ.get(SYS_ENV_VAR_API_TOKEN) is None:
-        raise SystemExit(f"Cannot find environment variable {SYS_ENV_VAR_API_TOKEN}")
+        raise SystemExit(
+            f"Cannot find environment variable {SYS_ENV_VAR_API_TOKEN}")
     if os.environ.get(SYS_ENV_VAR_GITHUB_TOKEN) is None:
-        raise SystemExit(f"Cannot find environment variable {SYS_ENV_VAR_GITHUB_TOKEN}")
+        raise SystemExit(
+            f"Cannot find environment variable {SYS_ENV_VAR_GITHUB_TOKEN}")
     if release and release not in VALID_RELEASES:
         raise SystemExit(f"{release} is not supported")
+
 
 @click.group()
 @click.option("--debug/--no-debug", help="enable debug logging")
@@ -360,6 +396,7 @@ def cli(debug):
         level=logging.DEBUG if debug else logging.INFO,
     )
 
+
 @click.command
 @click.option("-r", "--release", help="y-stream release number e.g. 4.15", required=True)
 @click.option("--nightly/--no-nightly", help="run controller for nightly or stable build, default is nightly", default=True)
@@ -367,13 +404,11 @@ def cli(debug):
 def start_controller(release, nightly, trigger_prow_job):
     JobController(release, nightly, trigger_prow_job).start()
 
+
 @click.command
 def start_aggregator():
     TestResultAggregator().start()
 
+
 cli.add_command(start_controller)
 cli.add_command(start_aggregator)
-
-
-    
-

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -24,12 +24,10 @@ SYS_ENV_VAR_API_TOKEN = "APITOKEN"
 VALID_RELEASES = ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
 RELEASE_STREAM_BASE_URL = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream"
 
-
 class JobController:
 
     def __init__(self, release, nightly=True, trigger_prow_job=True):
-        self._release = release[:-
-                                2] if len(release.split(".")) == 3 else release
+        self._release = release[:-2] if len(release.split("."))==3 else release
         self._nightly = nightly
         self._trigger_prow_job = trigger_prow_job
         self._build_type = 'nightly' if self._nightly else 'stable'
@@ -39,10 +37,9 @@ class JobController:
         validate_required_info(release)
         self.job_api = Jobs()
         self.job_registry = TestJobRegistry()
-        self.release_test_record = GithubUtil(
-            REPO_RELEASE_TESTS, BRANCH_RECORD)
+        self.release_test_record = GithubUtil(REPO_RELEASE_TESTS, BRANCH_RECORD)
         self.release_test_master = GithubUtil(REPO_RELEASE_TESTS)
-
+        
     def get_latest_build(self):
 
         try:
@@ -50,12 +47,10 @@ class JobController:
                 url = f"{RELEASE_STREAM_BASE_URL}/{self._release}.0-0.nightly/latest"
             else:
                 url = f"{RELEASE_STREAM_BASE_URL}/4-stable/latest?prefix={self._release}"
-                # if latest stable build is valid and not found, i.e. 4.16, we check releasestream 4-dev-preview instead
-                if requests.get(url).status_code == 404:
+                if requests.get(url).status_code == 404: # if latest stable build is valid and not found, i.e. 4.16, we check releasestream 4-dev-preview instead
                     url = f"{RELEASE_STREAM_BASE_URL}/4-dev-preview/latest"
 
-            logger.info(
-                f"Getting latest {self._build_type} build for {self._release} ...")
+            logger.info(f"Getting latest {self._build_type} build for {self._release} ...")
             resp = requests.get(url)
             resp.raise_for_status()
         except RequestException as re:
@@ -63,82 +58,69 @@ class JobController:
             raise
 
         if resp.text:
-            logger.info(
-                f"Latest  {self._build_type} build of {self._release} is:\n{resp.text}")
+            logger.info(f"Latest  {self._build_type} build of {self._release} is:\n{resp.text}")
             # if record file does not exist, create it on github repo
             if not self.release_test_record.file_exists(self._build_file):
-                self.release_test_record.push_file(
-                    data=resp.text, path=self._build_file)
-
+                self.release_test_record.push_file(data=resp.text, path=self._build_file)
+            
         return Build(resp.text)
-
+    
     def get_current_build(self):
         data = self.release_test_record.get_file_content(self._build_file)
         return Build(data)
-
+    
     def update_current_build(self, build):
         if build.raw_data:
-            self.release_test_record.push_file(
-                build.raw_data, self._build_file)
+            self.release_test_record.push_file(build.raw_data, self._build_file)
 
         logger.info(f"current build info is updated on repo")
 
     def trigger_prow_jobs(self, build):
 
-        test_jobs = self.job_registry.get_test_jobs(
-            self._release, self._nightly)
+        test_jobs = self.job_registry.get_test_jobs(self._release, self._nightly)
         test_result = []
         if len(test_jobs):
             for test_job in test_jobs:
                 if test_job.disabled:
-                    logger.info(
-                        f"Won't trigger prow job {test_job}, it is disabled")
+                    logger.info(f"Won't trigger prow job {test_job}, it is disabled")
                     continue
-
-                logger.info(
-                    f"Start to trigger prow job {test_job.prow_job} ...\n")
+      
+                logger.info(f"Start to trigger prow job {test_job.prow_job} ...\n")        
                 if test_job.upgrade:
-                    prow_job_id = self.job_api.run_job(
-                        job_name=test_job.prow_job, upgrade_to=build.pull_spec, upgrade_from=None, payload=None)
+                    prow_job_id = self.job_api.run_job(job_name=test_job.prow_job, upgrade_to=build.pull_spec, upgrade_from=None, payload=None)
                 else:
-                    prow_job_id = self.job_api.run_job(
-                        job_name=test_job.prow_job, payload=build.pull_spec, upgrade_from=None, upgrade_to=None)
-                logger.info(
-                    f"Triggered prow job {test_job.prow_job} with build {build.name}, job id={prow_job_id}\n")
-
+                    prow_job_id = self.job_api.run_job(job_name=test_job.prow_job, payload=build.pull_spec, upgrade_from=None, upgrade_to=None)
+                logger.info(f"Triggered prow job {test_job.prow_job} with build {build.name}, job id={prow_job_id}\n")
+                
                 job_item = {}
                 if prow_job_id:
                     job_item["jobName"] = test_job.prow_job
                     job_item["jobID"] = prow_job_id
                     test_result.append(job_item)
                 else:
-                    logger.error(
-                        f"Trigger prow job {test_job.prow_job} with build {build.name} failed, no prow job id returned")
+                    logger.error(f"Trigger prow job {test_job.prow_job} with build {build.name} failed, no prow job id returned")
 
             if len(test_result):
                 data = json.dumps({build.name: test_result}, indent=2)
                 logger.debug(f"Test result file content {data}")
                 file_path = f"{DIR_RELEASE}/ocp-test-result-{build.name}.json"
                 self.release_test_record.push_file(data=data, path=file_path)
-                logger.info(
-                    f"Test result of {build.name} is saved to {file_path}")
-
+                logger.info(f"Test result of {build.name} is saved to {file_path}")
+        
     def start(self):
         # get latest build info
         latest = self.get_latest_build()
         current = self.get_current_build()
         # compare whether current = latest, if latest is newer than current trigger prow jobs
         if latest.equals(current):
-            logger.info(
-                f"Current build is same as latest build {latest.name}, no diff found")
+            logger.info(f"Current build is same as latest build {latest.name}, no diff found")
         else:
             logger.info(f"Found new build {latest.name}")
             self.update_current_build(latest)
             if self._trigger_prow_job:
                 self.trigger_prow_jobs(latest)
             else:
-                logger.warning(
-                    "Won't trigger prow jobs since control flag [--trigger-prow-job] is false")
+                logger.warning("Won't trigger prow jobs since control flag [--trigger-prow-job] is false")
 
 
 class Build():
@@ -150,7 +132,7 @@ class Build():
     @property
     def name(self):
         return self._json_data["name"]
-
+    
     @property
     def phase(self):
         return self._json_data["phase"]
@@ -158,22 +140,21 @@ class Build():
     @property
     def pull_spec(self):
         return self._json_data["pullSpec"]
-
+    
     @property
     def download_url(self):
         return self._json_data["downloadURL"]
-
+    
     @property
     def raw_data(self):
         return self._raw_data
-
+    
     def equals(self, build):
         if isinstance(build, Build):
             return self.name == build.name
-
+        
         return False
-
-
+    
 class TestJob():
 
     def __init__(self, data):
@@ -182,22 +163,22 @@ class TestJob():
     @property
     def prow_job(self):
         return self._json_data["prowJob"]
-
+    
     @property
     def disabled(self):
         # default value is false
         return bool(self._json_data["disabled"]) if "disabled" in self._json_data else False
-
+    
     @property
     def upgrade(self):
         # default value is false
         return bool(self._json_data["upgrade"]) if "upgrade" in self._json_data else False
-
+    
     @property
     def optional(self):
         # default value is false
         return bool(self._json_data["optional"]) if "optional" in self._json_data else False
-
+    
 
 class GithubUtil:
 
@@ -228,14 +209,12 @@ class GithubUtil:
 
     def get_files(self, path):
         return self._repo.get_contents(path=path, ref=self._branch)
-
+            
     def get_file_content(self, path):
         content = self._repo.get_contents(path=path, ref=self._branch)
-        decoded_content = content.decoded_content.decode('utf-8')
-        logger.debug(
-            f"file content of {content.path} is:\n{decoded_content}")
-        return
-
+        logger.debug(f"file content of {content.path} is:\n{content.decoded_content.decode('utf-8')}")
+        return content.decoded_content.decode("utf-8")
+        
     def file_exists(self, path):
         try:
             self._repo.get_contents(path=path, ref=self._branch)
@@ -243,9 +222,9 @@ class GithubUtil:
         except UnknownObjectException:
             logger.info(f"File {path} not found")
             return False
-
+        
         return True
-
+    
     def delete_file(self, path):
         if self.file_exists(path):
             content = self._repo.get_contents(path=path, ref=self._branch)
@@ -258,7 +237,6 @@ class GithubUtil:
         else:
             logger.info(f"File {path} not found")
 
-
 class TestJobRegistry():
 
     def __init__(self):
@@ -268,21 +246,19 @@ class TestJobRegistry():
 
     def init(self):
         logger.info("Initializing test job registry ...")
-
+        
         contents = self.release_tests_master.get_files(DIR_RELEASE)
         for content in contents:
-            matched_path = re.search(
-                r'ocp-\d\.\d+-test-jobs.json', content.path)
-            if matched_path:
-                release = re.search(r'\d\.\d+', matched_path.group()).group()
-                file_content = self.release_tests_master.get_file_content(
-                    content.path)
-                self._registry[release] = json.loads(file_content)
-                logger.info(
-                    f"Test job definitions for {release} is initialized")
-
+                matched_path = re.search(r'ocp-\d\.\d+-test-jobs.json', content.path)
+                if matched_path:
+                    release = re.search(r'\d\.\d+', matched_path.group()).group()
+                    file_content = self.release_tests_master.get_file_content(content.path)
+                    self._registry[release] = json.loads(file_content)
+                    logger.info(f"Test job definitions for {release} is initialized")
+        
         logger.info("Test job registry is initialized")
-
+                    
+                    
     def get_test_jobs(self, release, nightly):
 
         test_jobs = []
@@ -294,24 +270,21 @@ class TestJobRegistry():
                 test_jobs.append(TestJob(job))
 
         return test_jobs
-
+    
     def get_test_job(self, release, nightly, job_name):
         jobs = self.get_test_jobs(release, nightly)
         filtered_jobs = [j for j in jobs if j.prow_job == job_name]
         if len(filtered_jobs):
             return filtered_jobs[0]
         else:
-            logger.info(
-                f"Cannot find test job {job_name} in {release} definition")
-
+            logger.info(f"Cannot find test job {job_name} in {release} definition")
 
 class TestResultAggregator():
-
+    
     def __init__(self):
         validate_required_info()
         self.job_registry = TestJobRegistry()
-        self.release_test_record = GithubUtil(
-            REPO_RELEASE_TESTS, BRANCH_RECORD)
+        self.release_test_record = GithubUtil(REPO_RELEASE_TESTS, BRANCH_RECORD)
         self.job_api = Jobs()
 
     def start(self):
@@ -323,8 +296,7 @@ class TestResultAggregator():
                 logger.info(f"Found test result file {matched_path.group()}")
                 release = re.search(r"\d\.\d+", matched_path.group()).group()
                 nightly = "nightly" in matched_path.group()
-                file_content = self.release_test_record.get_file_content(
-                    content.path)
+                file_content = self.release_test_record.get_file_content(content.path)
                 json_data = json.loads(file_content)
                 build = list(json_data.keys())[0]
                 logger.info(f"Start to check test result for {build} ...")
@@ -354,38 +326,30 @@ class TestResultAggregator():
                         completed_job_count += 1
                     else:
                         pending_job_count += 1
-                    job_meta = self.job_registry.get_test_job(
-                        release, nightly, job_name)
+                    job_meta = self.job_registry.get_test_job(release, nightly, job_name)
                     if not job_meta.optional:
-                        required_job_count += 1
-
-                self.release_test_record.push_file(
-                    data=json.dumps(json_data, indent=2), path=content.path)
-                logger.info(
-                    f"Latest test result of {build} is updated to file {content.path}")
+                       required_job_count += 1
+                    
+                self.release_test_record.push_file(data=json.dumps(json_data, indent=2), path=content.path)
+                logger.info(f"Latest test result of {build} is updated to file {content.path}")
 
                 # check if all the required jobs are success, if yes, update releasepayload with label release.openshift.io/qe_state=Accepted
                 qe_accepted = (required_job_count == success_job_count)
-                logger.info(
-                    f"Test result summary of {build}: all:{len(jobs)}, required:{required_job_count}, completed:{completed_job_count}, success:{success_job_count}, failed:{failed_job_count}, pending:{pending_job_count}, qe_accepted:{str(qe_accepted).lower()}")
-
+                logger.info(f"Test result summary of {build}: all:{len(jobs)}, required:{required_job_count}, completed:{completed_job_count}, success:{success_job_count}, failed:{failed_job_count}, pending:{pending_job_count}, qe_accepted:{str(qe_accepted).lower()}")
+                
                 if qe_accepted:
                     self.update_releasepayload()
-
+                    
     def update_releasepayload(self):
         pass
 
-
 def validate_required_info(release=None):
     if os.environ.get(SYS_ENV_VAR_API_TOKEN) is None:
-        raise SystemExit(
-            f"Cannot find environment variable {SYS_ENV_VAR_API_TOKEN}")
+        raise SystemExit(f"Cannot find environment variable {SYS_ENV_VAR_API_TOKEN}")
     if os.environ.get(SYS_ENV_VAR_GITHUB_TOKEN) is None:
-        raise SystemExit(
-            f"Cannot find environment variable {SYS_ENV_VAR_GITHUB_TOKEN}")
+        raise SystemExit(f"Cannot find environment variable {SYS_ENV_VAR_GITHUB_TOKEN}")
     if release and release not in VALID_RELEASES:
         raise SystemExit(f"{release} is not supported")
-
 
 @click.group()
 @click.option("--debug/--no-debug", help="enable debug logging")
@@ -396,7 +360,6 @@ def cli(debug):
         level=logging.DEBUG if debug else logging.INFO,
     )
 
-
 @click.command
 @click.option("-r", "--release", help="y-stream release number e.g. 4.15", required=True)
 @click.option("--nightly/--no-nightly", help="run controller for nightly or stable build, default is nightly", default=True)
@@ -404,11 +367,13 @@ def cli(debug):
 def start_controller(release, nightly, trigger_prow_job):
     JobController(release, nightly, trigger_prow_job).start()
 
-
 @click.command
 def start_aggregator():
     TestResultAggregator().start()
 
-
 cli.add_command(start_controller)
 cli.add_command(start_aggregator)
+
+
+    
+

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -369,14 +369,6 @@ class TestResultAggregator():
                     if not job_meta.optional:
                         required_job_count += 1
 
-                # if all the jobs are completed, we add a attribute to indicate this test result is aggregated
-                if len(jobs) == completed_job_count:
-                    json_data["aggregated"] = True
-                self.release_test_record.push_file(
-                    data=json.dumps(json_data, indent=2), path=content.path)
-                logger.info(
-                    f"Latest test result of {build} is updated to file {content.path}")
-
                 # check if all the required jobs are success, if yes, update releasepayload with label release.openshift.io/qe_state=Accepted
                 qe_accepted = (required_job_count == success_job_count)
                 logger.info(
@@ -384,6 +376,14 @@ class TestResultAggregator():
 
                 if qe_accepted:
                     self.update_releasepayload(build)
+
+                # if all the jobs are completed, we add a attribute to indicate this test result is aggregated
+                if len(jobs) == completed_job_count:
+                    json_data["aggregated"] = True
+                self.release_test_record.push_file(
+                    data=json.dumps(json_data, indent=2), path=content.path)
+                logger.info(
+                    f"Latest test result of {build} is updated to file {content.path}")
 
     def update_releasepayload(self, build):
 

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -18,6 +18,7 @@ import http.client as httpclient
 
 class Jobs:
     """Class Jobs handle Prow job by calling the API"""
+
     def __init__(self):
         self.run = False
         self.url = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
@@ -39,7 +40,7 @@ class Jobs:
             sys.exit(0)
 
     # it's for ARM test, now unable to find the 'cli' image in the provided ARM release image, but x86
-    # so extract the corresponding amd64 version from the arm64 build, 
+    # so extract the corresponding amd64 version from the arm64 build,
     # see bug: https://issues.redhat.com/browse/DPTP-3538, https://issues.redhat.com/browse/OCPQE-17600
     def get_amd_image_for_arm(self, payload):
         """Function get amd64 image as the ARM platform base image"""
@@ -48,9 +49,11 @@ class Jobs:
         if len(version) > 0:
             version_string = "".join(version[0])
             self.base_image = f"quay.io/openshift-release-dev/ocp-release:{version_string}-x86_64"
-            print(f"Infer the amd64 image: {self.base_image} from arm payload: {payload}")
+            print(
+                f"Infer the amd64 image: {self.base_image} from arm payload: {payload}")
         else:
-            print(f"Warning! Fail to get the corresponding amd64 base image, use the default one: {self.base_image}")
+            print(
+                f"Warning! Fail to get the corresponding amd64 base image, use the default one: {self.base_image}")
 
     def get_job_data(self, payload, upgrade_from, upgrade_to):
         """Function get prow job payload data"""
@@ -86,9 +89,11 @@ class Jobs:
             # x86 as default
             env = {"envs": {amd_latest: upgrade_from, amd_target: upgrade_to}}
             if "multi" in upgrade_from and "multi" in upgrade_to:
-                env = {"envs": {multi_latest: upgrade_from, multi_target: upgrade_to}}
+                env = {"envs": {multi_latest: upgrade_from,
+                                multi_target: upgrade_to}}
             if "ppc64le" in upgrade_from and "ppc64le" in upgrade_to:
-                env = {"envs": {ppc64le_latest: upgrade_from, ppc64le_target: upgrade_to}}
+                env = {"envs": {ppc64le_latest: upgrade_from,
+                                ppc64le_target: upgrade_to}}
             # check if it's for ARM, and amd_latest env is must no mater what platforms you run
             # if "arm64" in upgrade_from or "aarch64" in upgrade_from:
             #     self.get_amdBaseImage_for_arm(upgrade_from)
@@ -124,7 +129,8 @@ class Jobs:
                 env = {"envs": {ppc64le_latest: upgrade_from}}
             if "arm64" in upgrade_from or "aarch64" in upgrade_from:
                 self.get_amd_image_for_arm(upgrade_from)
-                env = {"envs": {amd_latest: self.base_image, arm_latest: upgrade_from}}
+                env = {"envs": {amd_latest: self.base_image,
+                                arm_latest: upgrade_from}}
         if env is not None:
             data = {"job_execution_type": "1", "pod_spec_options": env}
         print(data)
@@ -143,7 +149,8 @@ class Jobs:
 
     def push_action(self, url, data):
         """Function push data to the Github repo"""
-        res = requests.put(url=url, json=data, headers=self.get_github_headers())
+        res = requests.put(url=url, json=data,
+                           headers=self.get_github_headers())
         if res.status_code == 200:
             print(res.reason)
         else:
@@ -180,7 +187,8 @@ class Jobs:
                     self.run_required_jobs(channel, default_file, content)
             else:
                 self.run = False
-                print(f"No update! since the recored version {old_version} >= the new version {content}")
+                print(
+                    f"No update! since the recored version {old_version} >= the new version {content}")
         elif res.status_code == 404:
             print(f"file {url} doesn't exist, create it.")
             data = {
@@ -203,7 +211,8 @@ class Jobs:
         # it will use the default master branch
         res = requests.get(url=url, headers=self.get_github_headers())
         if res.status_code != 200:
-            print(f"Fail to get recored version! {res.status_code}:{res.reason}")
+            print(
+                f"Fail to get recored version! {res.status_code}:{res.reason}")
             return None
         return (base64.b64decode(json.loads(res.text)["content"]).decode("utf-8").replace("\n", ""))
 
@@ -230,7 +239,8 @@ class Jobs:
                     print(f'The latest version of {channel} is: {tag["name"]}')
                     file = f"Auto-OCP-{version[:-2]}.txt"
                     if push:
-                        self.push_versions(content=tag["name"], file=file, run=run)
+                        self.push_versions(
+                            content=tag["name"], file=file, run=run)
                     break
                 # else:
                 #     print("Not in the same Y release: %s" % new)
@@ -281,7 +291,8 @@ class Jobs:
                             payload = f"quay.io/openshift-release-dev/ocp-release:{version}-aarch64"
                         # specify the latest stable payload for upgrade test
                         if "upgrade-from-stable" in prow_job:
-                            self.run_job(prow_job, None, None, upgrade_to=payload)
+                            self.run_job(prow_job, None, None,
+                                         upgrade_to=payload)
                         # specify the latest stable payload for e2e test
                         elif "upgrade" not in prow_job:
                             self.run_job(prow_job, payload, None, None)
@@ -313,7 +324,8 @@ class Jobs:
                 print(f"Returned job id: {job_id}")
                 # wait 1s for the job startup
                 time.sleep(1)
-                self.get_job_results(job_id, job_name, payload, upgrade_from, upgrade_to)
+                self.get_job_results(
+                    job_id, job_name, payload, upgrade_from, upgrade_to)
             else:
                 print(f"Error code: {res.status_code}, reason: {res.reason}")
         else:
@@ -338,18 +350,22 @@ class Jobs:
                 continue
             print(">>>> " + file_name)
             url = f"https://api.github.com/repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/{file_name}?ref=master"
-            res = requests.get(url=url, headers=self.get_github_headers(), timeout=3)
+            res = requests.get(
+                url=url, headers=self.get_github_headers(), timeout=3)
             if res.status_code != 200:
-                continue 
-            response = requests.get(url=res.json()["git_url"], headers=self.get_github_headers(), timeout=3)
+                continue
+            response = requests.get(
+                url=res.json()["git_url"], headers=self.get_github_headers(), timeout=3)
             if response.status_code != 200:
                 continue
             # We have to get the git blobs when the size is very large, such as
             # git_url = 'https://api.github.com/repos/openshift/release/git/blobs/7546acab2fdc5fcde2df8d549df1d2886fcb4efc'
-            content = base64.b64decode(response.json()["content"].replace("\n", "")).decode("utf-8")
+            content = base64.b64decode(
+                response.json()["content"].replace("\n", "")).decode("utf-8")
             job_dict = yaml.load(content, Loader=yaml.FullLoader)
             if job_dict is None:
-                print(f"Warning! Couldn't get retunred JSON content when scanning: {file_name}!")
+                print(
+                    f"Warning! Couldn't get retunred JSON content when scanning: {file_name}!")
                 continue
             if job_name is not None:
                 for periodics_job in job_dict["periodics"]:
@@ -370,7 +386,8 @@ class Jobs:
                     job_url = status["url"]
                     job_state = status["state"]
                     job_start_time = status["startTime"]
-                    print(job_name, payload, job_id, job_start_time, job_url, job_state)
+                    print(job_name, payload, job_id,
+                          job_start_time, job_url, job_state)
                     job_dict = {
                         "jobName": job_name,
                         "payload": payload,
@@ -389,11 +406,13 @@ class Jobs:
                 else:
                     print("Not found the url link or creationTimestamp...")
             else:
-                print(f"return status code:{resp.status_code} reason:{resp.reason}")
+                print(
+                    f"return status code:{resp.status_code} reason:{resp.reason}")
         else:
             print("No job ID input, exit...")
             sys.exit(0)
 
+        return None
 
     def list_jobs(self, component, branch):
         """Function list prow jobs"""
@@ -412,15 +431,18 @@ class Jobs:
                     print(url)
                     self.get_jobs(url)
                     file_count += 1
-            print(f"Total file number under {component} folder is: {str(file_count)}")
+            print(
+                f"Total file number under {component} folder is: {str(file_count)}")
         else:
             print(req.reason)
 
     def get_jobs(self, url):
         """Function get prow jobs"""
-        res = requests.get(url=url, headers=self.get_github_headers(), timeout=3)
+        res = requests.get(
+            url=url, headers=self.get_github_headers(), timeout=3)
         if res.status_code == 200:
-            content = base64.b64decode(res.json()["content"].replace("\n", "")).decode("utf-8")
+            content = base64.b64decode(
+                res.json()["content"].replace("\n", "")).decode("utf-8")
             job_dict = yaml.load(content, Loader=yaml.FullLoader)
             api_count = 0
             for test_job in job_dict["tests"]:
@@ -462,9 +484,11 @@ class Jobs:
                     old = VersionInfo.parse(y_version+".0")
                     if new >= old:
                         if new.minor == old.minor:
-                            print(f'The latest version of {y_version} is: {tag["name"]}')
+                            print(
+                                f'The latest version of {y_version} is: {tag["name"]}')
                             latest_version = tag["name"]
-                            self.push_versions(content=latest_version, file=f"Auto-OCP-{y_version}.txt", run=False)
+                            self.push_versions(
+                                content=latest_version, file=f"Auto-OCP-{y_version}.txt", run=False)
                             break
             else:
                 # if no break, that means no new version found, so continue
@@ -489,6 +513,7 @@ class Jobs:
 
 
 JOB = Jobs()
+
 
 @click.group()
 @click.version_option(package_name="job")
@@ -570,6 +595,7 @@ def run_required(channel, file, version):
 def run_payloads(versions, push, run):
     """Check the latest stable payload of each version. Use comma spacing if multi versions, such as, 4.10.0,4.11.0,4.12.0"""
     JOB.get_payloads(versions, push, run)
+
 
 @cli.command("run_z_stream_test")
 def run_z_stream():


### PR DESCRIPTION
- if no prow job found from server side, i.e. the prow job is expired. we use updated job info from the test result instead.
- if all the jobs are completed, i.e. the test result was aggregated, insert a attribute `aggregated: true` to test result, and it will be skipped in next sync
- reformat `job.py` by pep8 style

```console
$ jobctl start-aggregator
2024-02-20T14:22:29Z: INFO: Initializing test job registry ...
2024-02-20T14:22:30Z: INFO: Test job definitions for 4.16 is initialized
2024-02-20T14:22:30Z: INFO: Test job registry is initialized
2024-02-20T14:22:31Z: INFO: Start to scan test result files ...
2024-02-20T14:22:32Z: INFO: Found test result file ocp-test-result-4.16.0-0.nightly-2024-02-03-221256.json
2024-02-20T14:22:32Z: INFO: Start to check test result for 4.16.0-0.nightly-2024-02-03-221256 ...
2024-02-20T14:22:32Z: INFO: test result of build 4.16.0-0.nightly-2024-02-03-221256 is already aggregated, skip
```