### PR TITLE
OCPQE-20409 Phase II add API support for risk analysis

### DIFF
--- a/prow/job/sippy.py
+++ b/prow/job/sippy.py
@@ -32,9 +32,9 @@ class Sippy():
             f"{'https' if self._secure else 'http'}://", self._adapter)
         return session
 
-    def _get_request(self, url, params):
+    def _get_request(self, url, params, data=None):
         session = self._get_session()
-        response = session.get(url, params=params, verify=False)
+        response = session.get(url, params=params, verify=False, data=data)
         response.raise_for_status()
 
         return response.json()
@@ -79,8 +79,9 @@ class Sippy():
             return self._get_request(url, ParamBuilder().prow_job_run_id(job_run_id).done())
 
         if payload:
-            # send post reuqest
-            return self._post_request(url, payload=payload, headers={"Content-Type": "application/json"})
+            # send get reuqest with payload
+            # https://github.com/openshift/sippy/blob/72a5f3e16bc99483db09155707ad14280c3a7554/pkg/sippyserver/server.go#L1080
+            return self._get_request(url, params=None, data=payload)
 
     def analyze_component_readiness(self, params) -> DataAnalyzer:
         return DataAnalyzer(self.query_component_readiness(params))

--- a/prow/job/sippy.py
+++ b/prow/job/sippy.py
@@ -39,12 +39,12 @@ class Sippy():
 
         return response.json()
 
-    def _post_request(self, url, payload, headers=None):
-        if not payload:
-            raise ValueError("request payload should not be empty")
+    def _post_request(self, url, data, headers=None):
+        if not data:
+            raise ValueError("request body should not be empty")
 
         session = self._get_session()
-        response = session.post(url, data=payload, headers=headers)
+        response = session.post(url, data=data, headers=headers)
         response.raise_for_status()
 
         return response.json()
@@ -69,19 +69,19 @@ class Sippy():
         url = f"{self._base_url}/variants"
         return self._get_request(url, params)
 
-    def query_risk_analysis(self, payload=None, job_run_id=None):
-        if payload is None and job_run_id is None:
-            raise ValueError("payload and job_run_id are all empty")
+    def query_risk_analysis(self, job_data=None, job_run_id=None):
+        if job_data is None and job_run_id is None:
+            raise ValueError("job data and job_run_id are all empty")
 
         url = f"{self._base_url}/jobs/runs/risk_analysis"
         if job_run_id:
             # send get request
             return self._get_request(url, ParamBuilder().prow_job_run_id(job_run_id).done())
 
-        if payload:
-            # send get reuqest with payload
+        if job_data:
+            # send get reuqest with json data
             # https://github.com/openshift/sippy/blob/72a5f3e16bc99483db09155707ad14280c3a7554/pkg/sippyserver/server.go#L1080
-            return self._get_request(url, params=None, data=payload)
+            return self._get_request(url, params=None, data=job_data)
 
     def analyze_component_readiness(self, params) -> DataAnalyzer:
         return DataAnalyzer(self.query_component_readiness(params))
@@ -89,8 +89,8 @@ class Sippy():
     def analyze_variants(self, params) -> DataAnalyzer:
         return DataAnalyzer(self.query_variant_status(params))
 
-    def analyze_job_run_risk(self, payload=None, job_run_id=None):
-        return DataAnalyzer(self.query_risk_analysis(payload=payload, job_run_id=job_run_id))
+    def analyze_job_run_risk(self, job_data=None, job_run_id=None):
+        return DataAnalyzer(self.query_risk_analysis(job_data=job_data, job_run_id=job_run_id))
 
 
 class ParamBuilder():
@@ -274,11 +274,11 @@ class StartEndTimePicker():
 
 class DataAnalyzer():
 
-    def __init__(self, payload: dict):
-        if payload:
-            self._data_set = payload
+    def __init__(self, data: dict):
+        if data:
+            self._data_set = data
         else:
-            raise ValueError("payload is empty")
+            raise ValueError("job data is empty")
 
     def is_component_readiness_status_green(self):
         '''

--- a/prow/job/sippy.py
+++ b/prow/job/sippy.py
@@ -14,7 +14,8 @@ class Sippy():
     def __init__(self, host, port=443, secure=True):
         self._host = host
         self._port = port
-        schema = "https" if secure else "http"
+        self._secure = secure
+        schema = "https" if self._secure else "http"
         self._base_url = f"{schema}://{self._host}:{self._port}/api"
 
         # define retry strategy
@@ -25,41 +26,70 @@ class Sippy():
 
         self._adapter = HTTPAdapter(max_retries=retry_strategy)
 
-    def _request(self, url, params):
+    def _get_session(self):
         session = requests.Session()
-        session.mount("http://", self._adapter)
-        session.mount("https://", self._adapter)
+        session.mount(
+            f"{'https' if self._secure else 'http'}://", self._adapter)
+        return session
 
+    def _get_request(self, url, params):
+        session = self._get_session()
         response = session.get(url, params=params, verify=False)
+        response.raise_for_status()
+
+        return response.json()
+
+    def _post_request(self, url, payload, headers=None):
+        if not payload:
+            raise ValueError("request payload should not be empty")
+
+        session = self._get_session()
+        response = session.post(url, data=payload, headers=headers)
         response.raise_for_status()
 
         return response.json()
 
     def health_check(self, release):
         url = f"{self._base_url}/health"
-        return self._request(url, ParamBuilder().release(release).done())
+        return self._get_request(url, ParamBuilder().release(release).done())
 
     def query_jobs(self, params):
         url = f"{self._base_url}/jobs"
-        return self._request(url, params)
+        return self._get_request(url, params)
 
     def query_tests(self, params):
         url = f"{self._base_url}/tests"
-        return self._request(url, params)
+        return self._get_request(url, params)
 
     def query_component_readiness(self, params):
         url = f"{self._base_url}/component_readiness"
-        return self._request(url, params)
+        return self._get_request(url, params)
 
     def query_variant_status(self, params):
         url = f"{self._base_url}/variants"
-        return self._request(url, params)
+        return self._get_request(url, params)
+
+    def query_risk_analysis(self, payload=None, job_run_id=None):
+        if payload is None and job_run_id is None:
+            raise ValueError("payload and job_run_id are all empty")
+
+        url = f"{self._base_url}/jobs/runs/risk_analysis"
+        if job_run_id:
+            # send get request
+            return self._get_request(url, ParamBuilder().prow_job_run_id(job_run_id).done())
+
+        if payload:
+            # send post reuqest
+            return self._post_request(url, payload=payload, headers={"Content-Type": "application/json"})
 
     def analyze_component_readiness(self, params) -> DataAnalyzer:
         return DataAnalyzer(self.query_component_readiness(params))
 
     def analyze_variants(self, params) -> DataAnalyzer:
         return DataAnalyzer(self.query_variant_status(params))
+
+    def analyze_job_run_risk(self, payload=None, job_run_id=None):
+        return DataAnalyzer(self.query_risk_analysis(payload=payload, job_run_id=job_run_id))
 
 
 class ParamBuilder():
@@ -149,6 +179,10 @@ class ParamBuilder():
 
     def period(self, period="towDay"):
         self._params.update(period=period)
+        return self
+
+    def prow_job_run_id(self, prow_job_run_id):
+        self._params.update(prow_job_run_id=prow_job_run_id)
         return self
 
     def done(self):
@@ -304,3 +338,20 @@ class DataAnalyzer():
         logger.info("Variants are analyzed")
 
         return len(issued_variants) == 0
+
+    def is_job_run_risky(self, threshold=50):
+        '''
+          Check risk level in job run risk analysis result
+        '''
+        job_name = self._data_set.get("ProwJobName")
+        job_run_id = self._data_set.get("ProwJobRunID")
+        level_dict = self._data_set.get("OverallRisk").get("Level")
+        level = level_dict.get("Level")
+        reasons = level_dict.get("Reasons")
+
+        risky = False
+        if level > threshold:
+            risky = True
+            logger.warning(f"{job_name} run {job_run_id} is risky: {reasons}")
+
+        return risky

--- a/tests/test_sippy.py
+++ b/tests/test_sippy.py
@@ -2,6 +2,7 @@ import unittest
 import logging
 import sys
 import urllib3
+import json
 from job.sippy import Sippy, DataAnalyzer
 from job.sippy import ParamBuilder, FilterBuilder, DatetimePicker, StartEndTimePicker
 
@@ -159,3 +160,54 @@ class TestSippy(unittest.TestCase):
         self.assertFalse(analyzer.is_variants_status_green())
         self.assertTrue(analyzer.is_variants_status_green(
             ['gcp', 'upgrade', 'realtime']))
+
+    def test_risk_analysis(self):
+
+        resp = self.sippy.query_risk_analysis(job_run_id='1767798075599884288')
+        logger.info(resp)
+        self.assertIn('OverallRisk', resp)
+        self.assertIn('Level', resp.get('OverallRisk'))
+
+        payload = {
+            "ID": 1767798075599884288,
+            "ProwJob": {
+                "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
+            },
+            "ClusterData": {
+                "Release": "4.16",
+                "FromRelease": "",
+                "Platform": "aws",
+                "Architecture": "amd64",
+                "Network": "ovn",
+                "Topology": "ha",
+                "NetworkStack": "IPv4",
+                "CloudRegion": "us-west-1",
+                "CloudZone": "us-west-1c",
+                "ClusterVersionHistory": [
+                    "4.16.0-0.nightly-2024-03-13-061822"
+                ],
+                "MasterNodesUpdated": "N"
+            },
+            "Tests": [],
+            "TestCount": 532
+        }
+
+        resp = self.sippy.query_risk_analysis(
+            json.dumps(payload).encode("utf-8"))
+        logger.info(resp)
+        self.assertIn('OverallRisk', resp)
+        self.assertIn('Level', resp.get('OverallRisk'))
+
+        path = "/tmp/req_body.txt"
+        with open(path, 'w') as f:
+            f.write(json.dumps(payload))
+
+        with open(path, "r") as f:
+            resp = self.sippy.query_risk_analysis(f.read())
+            logger.info(resp)
+
+    def test_analyze_job_run_risk(self):
+
+        analyzer = self.sippy.analyze_job_run_risk(
+            job_run_id='1767798075599884288')
+        self.assertFalse(analyzer.is_job_run_risky())

--- a/tests/test_sippy.py
+++ b/tests/test_sippy.py
@@ -168,7 +168,7 @@ class TestSippy(unittest.TestCase):
         self.assertIn('OverallRisk', resp)
         self.assertIn('Level', resp.get('OverallRisk'))
 
-        payload_a = {
+        job_data_a = {
             "ID": 1767798075599884288,
             "ProwJob": {
                 "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
@@ -176,7 +176,7 @@ class TestSippy(unittest.TestCase):
             "TestCount": 100
         }
 
-        payload_b = {
+        job_data_b = {
             "ID": 1767798075599884288,
             "ProwJob": {
                 "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
@@ -200,17 +200,17 @@ class TestSippy(unittest.TestCase):
             "TestCount": 532
         }
 
-        payloads = [payload_a, payload_b]
-        for p in payloads:
+        job_datas = [job_data_a, job_data_b]
+        for jd in job_datas:
             resp = self.sippy.query_risk_analysis(
-                json.dumps(p).encode("utf-8"))
+                json.dumps(jd).encode("utf-8"))
             logger.info(resp)
             self.assertIn('OverallRisk', resp)
             self.assertIn('Level', resp.get('OverallRisk'))
 
         path = "/tmp/req_body.txt"
         with open(path, 'w') as f:
-            f.write(json.dumps(payload_b))
+            f.write(json.dumps(job_data_b))
 
         with open(path, "r") as f:
             resp = self.sippy.query_risk_analysis(f.read())

--- a/tests/test_sippy.py
+++ b/tests/test_sippy.py
@@ -168,7 +168,7 @@ class TestSippy(unittest.TestCase):
         self.assertIn('OverallRisk', resp)
         self.assertIn('Level', resp.get('OverallRisk'))
 
-        payload = {
+        payload_a = {
             "ID": 1767798075599884288,
             "ProwJob": {
                 "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
@@ -176,13 +176,7 @@ class TestSippy(unittest.TestCase):
             "TestCount": 100
         }
 
-        resp = self.sippy.query_risk_analysis(
-            json.dumps(payload).encode("utf-8"))
-        logger.info(resp)
-        self.assertIn('OverallRisk', resp)
-        self.assertIn('Level', resp.get('OverallRisk'))
-
-        payload = {
+        payload_b = {
             "ID": 1767798075599884288,
             "ProwJob": {
                 "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
@@ -206,15 +200,17 @@ class TestSippy(unittest.TestCase):
             "TestCount": 532
         }
 
-        resp = self.sippy.query_risk_analysis(
-            json.dumps(payload).encode("utf-8"))
-        logger.info(resp)
-        self.assertIn('OverallRisk', resp)
-        self.assertIn('Level', resp.get('OverallRisk'))
+        payloads = [payload_a, payload_b]
+        for p in payloads:
+            resp = self.sippy.query_risk_analysis(
+                json.dumps(p).encode("utf-8"))
+            logger.info(resp)
+            self.assertIn('OverallRisk', resp)
+            self.assertIn('Level', resp.get('OverallRisk'))
 
         path = "/tmp/req_body.txt"
         with open(path, 'w') as f:
-            f.write(json.dumps(payload))
+            f.write(json.dumps(payload_b))
 
         with open(path, "r") as f:
             resp = self.sippy.query_risk_analysis(f.read())

--- a/tests/test_sippy.py
+++ b/tests/test_sippy.py
@@ -173,6 +173,20 @@ class TestSippy(unittest.TestCase):
             "ProwJob": {
                 "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
             },
+            "TestCount": 100
+        }
+
+        resp = self.sippy.query_risk_analysis(
+            json.dumps(payload).encode("utf-8"))
+        logger.info(resp)
+        self.assertIn('OverallRisk', resp)
+        self.assertIn('Level', resp.get('OverallRisk'))
+
+        payload = {
+            "ID": 1767798075599884288,
+            "ProwJob": {
+                "Name": "periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-ovn-serial"
+            },
             "ClusterData": {
                 "Release": "4.16",
                 "FromRelease": "",


### PR DESCRIPTION
## Add API support to query risk analysis
- query risk analysis with job run id with get request
- query risk analysis with payload json file with get request
- analyze response data to determine whether the job run is risky