### PR TITLE
OCPQE-20766 add suite name for failed case

### DIFF
--- a/prow/job/artifacts.py
+++ b/prow/job/artifacts.py
@@ -106,8 +106,10 @@ class JunitTestReport():
             else:
                 raise FileNotFoundError(f"{file_path} not found")
 
+        self._test_summary = JunitTestSummary(self._root)
+
     def get_test_summary(self):
-        return JunitTestSummary(self._root)
+        return self._test_summary
 
     def get_failed_tests(self):
         test_cases = []
@@ -119,7 +121,7 @@ class JunitTestReport():
                     # https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-upi/1776477546024538112/artifacts/e2e-aws-ovn-upi/openshift-e2e-test/artifacts/junit/test-failures-summary_20240406-055752.json
                     test_cases.append({
                         "Test": {"Name": tc.name},
-                        "Suite": {"Name": "openshift-tests-private"},
+                        "Suite": {"Name": self.get_test_summary().name},
                         "Status": 12
                     })
 


### PR DESCRIPTION
make a minor change to get suite name of failed test from root element of junit xml
```
$ py -m unittest test_artifacts.TestArtifacts.test_generate_job_summary
2024-04-15T14:05:27Z: INFO: {
  "ID": 1775675266119503872,
  "ProwJob": {
    "Name": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-aws-ipi-fips-f1"
  },
  "Tests": [
    {
      "Test": {
        "Name": "OCP-37491:SDN EgressFirewall allows traffic to destination dnsName"
      },
      "Suite": {
        "Name": "Egress-ingress related networking scenarios"
      },
      "Status": 12
    }
  ],
  "TestCount": 256
}
```