### PR TITLE
OCPQE-22219 add test jobs definition for 4.16 release

### DIFF
--- a/_releases/ocp-4.16-test-jobs-amd64.json
+++ b/_releases/ocp-4.16-test-jobs-amd64.json
@@ -1,18 +1,41 @@
 {
   "nightly": [
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-aws-c2s-ipi-disconnected-private-fips-f14",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-ipi-private-shared-vpc-phz-sts-f360"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-azure-ipi-workers-rhel8-f14",
-      "disabled": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-stack-upi-f360"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-4.16-upgrade-from-stable-4.15-aws-ipi-disconnected-sts-basecap-none-f28",
-      "upgrade": true,
-      "retries": 3
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-gcp-ipi-mini-perm-custom-type-f360"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetalds-ipi-ovn-dualstack-primaryv6-f360"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-vsphere-ipi-ovn-dualstack-f360"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-aws-ipi-private-shared-vpc-phz-sts-f360",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-gcp-ipi-mini-perm-custom-type-f360",
+      "upgrade": true
     }
   ],
-  "stable": []
+  "stable": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-aws-ipi-private-shared-vpc-phz-sts-f360",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-gcp-ipi-mini-perm-custom-type-f360",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-azure-stack-upi-f360",
+      "upgrade": true
+    }
+  ]
 }


### PR DESCRIPTION
Select prow jobs for 4.16 nightly/stable from automated release job pool

https://github.com/openshift/release/blob/master/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16__automated-release.yaml
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16__automated-release-stable-4.16-upgrade-from-stable-4.16.yaml

/assign @liangxia @jianzhangbjz @jhou1 @chengzhang1016 

Can you review and comment. TODO: enable job controller job when this PR is merged.
