### PR TITLE
OCPQE-22219 catch error for getting job result

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -454,7 +454,10 @@ class ProwJobResult():
         return self
 
     def fetch(self, job_id):
-        self.from_dict(self.job_api.get_job_results(job_id))
+        try:
+            self.from_dict(self.job_api.get_job_results(job_id))
+        except Exception as e:
+            logger.error(f"fetch job result error: {e}")
         return self
 
 

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -327,8 +327,11 @@ class Jobs:
                 print(f"Returned job id: {job_id}")
                 # wait 1s for the job startup
                 time.sleep(5)
-                self.get_job_results(
-                    job_id, job_name, payload, upgrade_from, upgrade_to)
+                try:
+                    self.get_job_results(
+                        job_id, job_name, payload, upgrade_from, upgrade_to)
+                except Exception as e:
+                    print(f"get job result error: {e}")
             else:
                 print(f"Error code: {res.status_code}, reason: {res.reason}")
         else:


### PR DESCRIPTION
Fix error in job https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-tests-master-qe-release-gate-test/1792484273572286464/artifacts/qe-release-gate-test/release-qe-tests/build-log.txt

Solution: sometimes api cannot get job url, but it does not matter for func `run_job`, we just need `job_id`. so exceptions raised from this func can be ignored.