### PR TITLE
OCPQE-22219 disable azure-stack job due to insufficient capacity

### DIFF
--- a/_releases/ocp-4.16-test-jobs-amd64.json
+++ b/_releases/ocp-4.16-test-jobs-amd64.json
@@ -4,7 +4,11 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-ipi-private-shared-vpc-phz-sts-f360"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-stack-upi-f360"
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-stack-upi-f360",
+      "disabled": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-ipi-marketplace-mini-perm-f360"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-gcp-ipi-mini-perm-custom-type-f360"
@@ -35,7 +39,8 @@
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-azure-stack-upi-f360",
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     }
   ]
 }


### PR DESCRIPTION
According to install failure analysis. azure-stack based automated release job does not have enough capacity to support testing frequency of nightly and stable