### PR TITLE
OCPQE-22219 disable baremetal job due to install failures

### DIFF
--- a/_releases/ocp-4.16-test-jobs-amd64.json
+++ b/_releases/ocp-4.16-test-jobs-amd64.json
@@ -14,7 +14,8 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-gcp-ipi-mini-perm-custom-type-f360"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetalds-ipi-ovn-dualstack-primaryv6-f360"
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetalds-ipi-ovn-dualstack-primaryv6-f360",
+      "disabled": true
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-vsphere-ipi-ovn-dualstack-f360"


### PR DESCRIPTION
disable job periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetalds-ipi-ovn-dualstack-primaryv6-f360, there are too many install failures observed. 