### PR TITLE
OCPQE-22219 add automate release job implementation

### DIFF
--- a/prow/job/selector.py
+++ b/prow/job/selector.py
@@ -1,0 +1,49 @@
+from ast import List
+import logging
+import requests
+import yaml
+from .controller import GithubUtil
+from github.GithubException import UnknownObjectException
+from requests.exceptions import RequestException
+
+logger = logging.getLogger(__name__)
+
+
+class AutoReleaseJobs():
+
+    def __init__(self, release) -> None:
+        if not release:
+            raise ValueError("param <release> is mandatory")
+        self._release = release
+
+        # env var GITHUB_TOKEN is required
+        self.release_master = GithubUtil("openshift/release")
+
+    def get_jobs(self) -> list[str]:
+        # get automated release jobs from github repo openshift/release by different releases
+        # currently only release 4.15,4.16 are supported.
+        auto_release_jobs = []
+        # check whether job file exists for the requested release
+        file_path = f"ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-{self._release}-periodics.yaml"
+        if not self.release_master.file_exists(file_path):
+            raise FileNotFoundError(
+                f"automate release job file cannot be found for release {self._release}")
+
+        # because the file size is too big, the raw content won't be sent back via api call
+        # we need to download the raw file content separately
+        raw_data_url = self.release_master.get_files(file_path).download_url
+        resp = requests.get(raw_data_url)
+        resp.raise_for_status()
+
+        file_content = resp.text
+        if file_content:
+            # parse yaml file to get all the jobs with key word automated-release
+            yaml_file = yaml.safe_load(file_content)
+            for job_obj in yaml_file.get("periodics"):
+                # TODO:currently we just need the job name, if the selection policy needs more job info
+                # we can put job object to the list in the future
+                job_name = job_obj.get("name")
+                if "automated-release" in job_name:
+                    auto_release_jobs.append(job_name)
+
+        return auto_release_jobs

--- a/prow/job/selector.py
+++ b/prow/job/selector.py
@@ -1,4 +1,3 @@
-from ast import List
 import logging
 import requests
 import yaml

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -16,8 +16,8 @@ class TestSelector(unittest.TestCase):
         pass
 
     def test_get_not_supported_release(self):
-        self.assertRaises(FileNotFoundError, AutoReleaseJobs, "4.13")
-        self.assertRaises(FileNotFoundError, AutoReleaseJobs, "4.14")
+        with self.assertRaises(FileNotFoundError):
+            AutoReleaseJobs("4.13").get_jobs()
 
     def test_get_auto_release_jobs(self):
         for release in ["4.15", "4.16"]:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,28 @@
+import unittest
+import logging
+from job.selector import AutoReleaseJobs
+
+logging.basicConfig(
+    format="%(asctime)s: %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+    level=logging.DEBUG
+)
+logger = logging.getLogger(__name__)
+
+
+class TestSelector(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_not_supported_release(self):
+        self.assertRaises(FileNotFoundError, AutoReleaseJobs, "4.13")
+        self.assertRaises(FileNotFoundError, AutoReleaseJobs, "4.14")
+
+    def test_get_auto_release_jobs(self):
+        for release in ["4.15", "4.16"]:
+            jobs = AutoReleaseJobs(release).get_jobs()
+            self.assertTrue(len(jobs) > 0)
+            for job in jobs:
+                logger.info(job)
+                self.assertRegex(job, "automated-release")


### PR DESCRIPTION
- Add class `AutoReleaseJobs` to get auto release jobs for different releases
   - currently only support amd64 jobs

- Unit test results

```console
$ py -m unittest test_selector.TestSelector.test_get_not_supported_release
2024-05-22T15:45:19Z: DEBUG: Starting new HTTPS connection (1): api.github.com:443
2024-05-22T15:45:20Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release HTTP/1.1" 200 None
2024-05-22T15:45:20Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.13__automated-release.yaml?ref=master HTTP/1.1" 404 None
2024-05-22T15:45:20Z: INFO: File ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.13__automated-release.yaml not found
.
----------------------------------------------------------------------
Ran 1 test in 1.412s

OK
```

```console
$ py -m unittest test_selector.TestSelector.test_get_auto_release_jobs
2024-05-22T15:45:55Z: DEBUG: Starting new HTTPS connection (1): api.github.com:443
2024-05-22T15:45:55Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release HTTP/1.1" 200 None
2024-05-22T15:45:56Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.15__automated-release.yaml?ref=master HTTP/1.1" 200 None
2024-05-22T15:45:56Z: INFO: File ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.15__automated-release.yaml can be found
2024-05-22T15:45:56Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.15-periodics.yaml?ref=master HTTP/1.1" 200 None
2024-05-22T15:45:57Z: DEBUG: Starting new HTTPS connection (1): raw.githubusercontent.com:443
2024-05-22T15:45:57Z: DEBUG: https://raw.githubusercontent.com:443 "GET /openshift/release/master/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.15-periodics.yaml HTTP/1.1" 200 39335
2024-05-22T15:45:59Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-aws-ipi-fips-f1
2024-05-22T15:45:59Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-stable-4.15-upgrade-from-stable-4.15-aws-ipi-fips-amd-f1
2024-05-22T15:45:59Z: DEBUG: Starting new HTTPS connection (1): api.github.com:443
2024-05-22T15:46:00Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release HTTP/1.1" 200 None
2024-05-22T15:46:00Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16__automated-release.yaml?ref=master HTTP/1.1" 200 None
2024-05-22T15:46:00Z: INFO: File ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16__automated-release.yaml can be found
2024-05-22T15:46:01Z: DEBUG: https://api.github.com:443 "GET /repos/openshift/release/contents/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16-periodics.yaml?ref=master HTTP/1.1" 200 None
2024-05-22T15:46:01Z: DEBUG: Starting new HTTPS connection (1): raw.githubusercontent.com:443
2024-05-22T15:46:01Z: DEBUG: https://raw.githubusercontent.com:443 "GET /openshift/release/master/ci-operator/jobs/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.16-periodics.yaml HTTP/1.1" 200 45617
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-ipi-private-shared-vpc-phz-sts-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-sc2s-ipi-disc-priv-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-usgov-ipi-private-ep-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-ipi-marketplace-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-stack-ipi-proxy-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-azure-stack-upi-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetal-pxe-sno-agent-ipv4-static-connected-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-baremetalds-ipi-ovn-dualstack-primaryv6-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-gcp-ipi-mini-perm-custom-type-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-ibmcloud-ipi-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-nutanix-ipi-proxy-fips-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-aws-ipi-private-shared-vpc-phz-sts-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-aws-sc2s-ipi-disc-priv-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-aws-usgov-ipi-private-ep-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-azure-ipi-marketplace-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-azure-stack-ipi-proxy-fips-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-azure-stack-upi-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-baremetal-pxe-sno-agent-ipv4-static-connected-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-baremetalds-ipi-ovn-dualstack-primaryv6-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-gcp-ipi-mini-perm-custom-type-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-ibmcloud-ipi-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-nutanix-ipi-proxy-fips-mini-perm-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.16-vsphere-ipi-ovn-dualstack-f360
2024-05-22T15:46:04Z: INFO: periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-vsphere-ipi-ovn-dualstack-f360
.
----------------------------------------------------------------------
Ran 1 test in 9.300s

OK
```