### PR TITLE
update go version

### DIFF
--- a/prow/Dockerfile.k8sgpt
+++ b/prow/Dockerfile.k8sgpt
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.21-openshift-4.16
+FROM golang:1.22
 LABEL maintainer="jiazha@redhat.com"
 WORKDIR /go/src/github.com/k8sgpt-ai
 RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git && \


### PR DESCRIPTION
Addressed https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release-tests/194/pull-ci-openshift-release-tests-master-images/1801420599180922880 
```go
Cloning into 'k8sgpt'...
go: go.mod requires go >= 1.22.0 (running go 1.21.9; GOTOOLCHAIN=local)
error: build error: building at STEP "RUN git clone --branch main https://github.com/k8sgpt-ai/k8sgpt.git &&     cd k8sgpt &&     go mod vendor &&     make build": while running runtime: exit status 1
```