### PR TITLE
OCPQE-22653 replace aws vpc job with mini perm job

### DIFF
--- a/_releases/ocp-4.12-test-jobs-amd64.json
+++ b/_releases/ocp-4.12-test-jobs-amd64.json
@@ -1,7 +1,7 @@
 {
   "nightly": [
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-aws-ipi-private-shared-vpc-phz-sts-fips-f360"
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-aws-ipi-mini-perm-f360"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-azure-ipi-mini-perm-fips-f360"
@@ -10,7 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-gcp-ipi-mini-perm-custom-type-f360"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-aws-ipi-private-shared-vpc-phz-sts-fips-f360",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-aws-ipi-mini-perm-f360",
       "upgrade": true
     },
     {
@@ -20,7 +20,7 @@
   ],
   "stable": [
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-aws-ipi-private-shared-vpc-phz-sts-fips-f360",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-aws-ipi-mini-perm-f360",
       "upgrade": true
     },
     {


### PR DESCRIPTION
According to discussion with installer team [redhat-internal.slack.com/archives/CH76YSYSC/p1718587132710229](https://redhat-internal.slack.com/archives/CH76YSYSC/p1718587132710229)
>  shared-vpc is not officially supported in 4.12

Remove share vpc related auto release job from 4.12 job registry