### PR TITLE
remove record file creation when getting latest build

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -196,7 +196,6 @@ class JobController:
         self.release_test_master = GithubUtil(REPO_RELEASE_TESTS)
 
     def get_latest_build(self):
-
         try:
             logger.info(
                 f"Getting latest {self._build_type} build for {self._release} ...")
@@ -209,10 +208,6 @@ class JobController:
         if resp.text:
             logger.info(
                 f"Latest {self._build_type} build of {self._release} is:\n{resp.text}")
-            # if record file does not exist, create it on github repo
-            if not self.release_test_record.file_exists(self._build_file):
-                self.release_test_record.push_file(
-                    data=resp.text, path=self._build_file)
 
         return Build(resp.text)
 


### PR DESCRIPTION
currently logic is when getting latest build, if record file does not exist, create it on github, the logic is useless
remove this logic, when the file does not exist, i.e. current build not found, so controller will trigger test and create the file accordingly.
```console
$ jobctl start-controller -r 4.13 --nightly --trigger-prow-job false
2024-07-09T08:12:17Z: INFO: Initializing test job registry ...
2024-07-09T08:12:18Z: INFO: Test job definitions for 4.12-amd64 is initialized
2024-07-09T08:12:19Z: INFO: Test job definitions for 4.15-amd64 is initialized
2024-07-09T08:12:19Z: INFO: Test job definitions for 4.16-amd64 is initialized
2024-07-09T08:12:19Z: INFO: Test job registry is initialized
2024-07-09T08:12:22Z: INFO: Getting latest nightly build for 4.13 ...
2024-07-09T08:12:23Z: INFO: Latest nightly build of 4.13 is:
{
  "name": "4.13.0-0.nightly-2024-07-08-125413",
  "phase": "Accepted",
  "pullSpec": "registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2024-07-08-125413",
  "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.13.0-0.nightly-2024-07-08-125413"
}

2024-07-09T08:12:23Z: INFO: File _releases/ocp-latest-4.13-nightly-amd64.json not found
2024-07-09T08:12:23Z: INFO: Found new build 4.13.0-0.nightly-2024-07-08-125413
2024-07-09T08:12:24Z: INFO: File _releases/ocp-latest-4.13-nightly-amd64.json not found
2024-07-09T08:12:24Z: INFO: Creating file _releases/ocp-latest-4.13-nightly-amd64.json
2024-07-09T08:12:24Z: INFO: File is created successfully
2024-07-09T08:12:24Z: INFO: current build info is updated on repo
2024-07-09T08:12:24Z: WARNING: Won't trigger prow jobs since control flag [--trigger-prow-job] is false
rio.liu@Rios-Laptop:coderepo/release-tests ‹refine-get-latest-build-logic*›$
rio.liu@Rios-Laptop:coderepo/release-tests ‹refine-get-latest-build-logic*›$ jobctl start-controller -r 4.14 --nightly --trigger-prow-job false
```