### PR TITLE
refine cmd take-ownership

### DIFF
--- a/oar/cli/cmd_take_ownership.py
+++ b/oar/cli/cmd_take_ownership.py
@@ -1,5 +1,6 @@
 import click
 import logging
+import re
 import oar.core.util as util
 from oar.core.worksheet_mgr import WorksheetManager, WorksheetException
 from oar.core.jira_mgr import JiraManager, JiraException
@@ -11,11 +12,20 @@ from oar.core.const import *
 logger = logging.getLogger(__name__)
 
 
+def validate_email(ctx, param, value):
+    email_pattern = re.compile(
+        r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+    if not email_pattern.match(value):
+        raise click.BadParameter(f"{value} is not a valid email")
+    return value
+
+
 @click.command()
 @click.option(
     "-e",
     "--email",
     required=True,
+    callback=validate_email,
     help="email address of the owner",
 )
 @click.pass_context

--- a/oar/core/jira_mgr.py
+++ b/oar/core/jira_mgr.py
@@ -168,7 +168,8 @@ class JiraManager:
         if len(subtasks):
             for st in subtasks:
                 if st.get_summary() in JIRA_QE_TASK_SUMMARIES:
-                    self.assign_issue(st.get_key(), self._cs.get_owner())
+                    self.assign_issue(
+                        st.get_key(), self._cs.get_owner().split('@')[0])
                     updated_tasks.append(st.get_key())
                     if st.get_summary().startswith(
                         "[Wed-Fri]"


### PR DESCRIPTION
- user email id to query jira user
- valid email address
```console
$ oar -r 4.12.60 take-ownership -e rioliu
Usage: oar take-ownership [OPTIONS]
Try 'oar take-ownership -h' for help.

Error: Invalid value for '-e' / '--email': rioliu is not a valid email address
```