### PR TITLE
OCPQE-24160  check file signature-1 instead of dir on mirror.openshift.com

### DIFF
--- a/oar/cli/cmd_image_signed_check.py
+++ b/oar/cli/cmd_image_signed_check.py
@@ -33,7 +33,8 @@ def get_image_digest(url, current_try=0):
 
     if not digest:
         if current_try == max_retries:
-            logger.error(f"Imgage digest failed to show after {max_retries} retries!")
+            logger.error(
+                f"Imgage digest failed to show after {max_retries} retries!")
             return
         else:
             logger.debug(f"Current try: {current_try}")
@@ -55,9 +56,11 @@ def image_signed_check(ctx):
     """
     cs = ctx.obj["cs"]
     report = WorksheetManager(cs).get_test_report()
-    image_signed_check_result = report.get_task_status(LABEL_TASK_PAYLOAD_IMAGE_VERIFY)
+    image_signed_check_result = report.get_task_status(
+        LABEL_TASK_PAYLOAD_IMAGE_VERIFY)
     if image_signed_check_result == TASK_STATUS_PASS:
-        logger.info("image signed check already pass, not need to trigger again")
+        logger.info(
+            "image signed check already pass, not need to trigger again")
     else:
         report.update_task_status(
             LABEL_TASK_PAYLOAD_IMAGE_VERIFY, TASK_STATUS_INPROGRESS
@@ -71,7 +74,7 @@ def image_signed_check(ctx):
             digest_sha = get_image_digest(release_url)
             reformatted_digest = digest_sha.replace(":", "=")
             # 2. query the mirror location
-            mirror_url = cs.get_signature_url() + reformatted_digest + "/"
+            mirror_url = f"{cs.get_signature_url()}{reformatted_digest}/signature-1"
             logger.info(f"Comparing digest from url: {mirror_url}")
             rest = requests.get(mirror_url)
             rest.raise_for_status()
@@ -82,5 +85,6 @@ def image_signed_check(ctx):
                 )
         except RequestException:
             logger.exception("Visit release/mirror url failed")
-            report.update_task_status(LABEL_TASK_PAYLOAD_IMAGE_VERIFY, TASK_STATUS_FAIL)
+            report.update_task_status(
+                LABEL_TASK_PAYLOAD_IMAGE_VERIFY, TASK_STATUS_FAIL)
             raise


### PR DESCRIPTION
```console
$ oar -v -r 4.12.61 image-signed-check
2024-07-23T18:29:33Z: INFO: task [Payload image is well signed] status is changed to [In Progress]
2024-07-23T18:29:34Z: INFO: Getting digest from https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/4.12.61
2024-07-23T18:29:37Z: INFO: Image Digest: sha256:faa201ea7790bb101de7b9b6f01543136e8c589463b8437a10678da0cdd0197a
2024-07-23T18:29:37Z: INFO: Comparing digest from url: https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/sha256=faa201ea7790bb101de7b9b6f01543136e8c589463b8437a10678da0cdd0197a/signature-1
2024-07-23T18:29:38Z: INFO: Signature check PASSED
2024-07-23T18:29:39Z: INFO: task [Payload image is well signed] status is changed to [Pass]
```
slack thread: https://redhat-internal.slack.com/archives/CB95J6R4N/p1721702244816089