### PR TITLE
OCPQE-24321 check secalert for RHSA advisory

### DIFF
--- a/tests/test_advisory_mgr.py
+++ b/tests/test_advisory_mgr.py
@@ -60,4 +60,11 @@ class TestAdvisoryManager(unittest.TestCase):
         self.me = AdvisoryManager(ConfigStore("4.13.15"))
         ads = self.me.get_advisories()
         for ad in ads:
-            self.assertNotEqual(ad.errata_state, AD_STATUS_DROPPED_NO_SHIP, "AD with DROOPED NO SHIP hasn't been fileter out")
+            self.assertNotEqual(ad.errata_state, AD_STATUS_DROPPED_NO_SHIP,
+                                "AD with DROOPED NO SHIP hasn't been fileter out")
+
+    def test_get_security_alerts(self):
+        self.me = AdvisoryManager(ConfigStore("4.12.61"))
+        ads = self.me.get_advisories()
+        for ad in ads:
+            self.assertFalse(ad.has_blocking_secruity_alert(), f"advisory {ad.errata_id} has blocking security alerts")


### PR DESCRIPTION
erratum API supports getting secalert for advisory. add new funcs to check whether there is any blocking secalert
```
$ py -m unittest test_advisory_mgr.TestAdvisoryManager.test_get_security_alerts
2024-07-30T15:32:16Z: WARNING: RHBA advisory 136330 does not have secalerts
2024-07-30T15:32:18Z: INFO: RHSA advisory 136331 does not have blocking secalert
2024-07-30T15:32:18Z: WARNING: RHBA advisory 136332 does not have secalerts
2024-07-30T15:32:18Z: WARNING: RHBA advisory 136333 does not have secalerts
.
----------------------------------------------------------------------
Ran 1 test in 60.227s

OK
```