### PR TITLE
OCPQE-24474 add prompt for detector option

### DIFF
--- a/oar/controller/detector.py
+++ b/oar/controller/detector.py
@@ -81,6 +81,10 @@ def validate_minor_release(ctx, param, value):
 
 
 @click.command()
-@click.option("-r", "--minor-release", help="Minor rlease of OCP e.g. 4.y", required=True, callback=validate_minor_release)
+@click.option("-r", "--minor-release",
+              help="Minor rlease of OCP e.g. 4.y",
+              prompt="Please input the minor version of OCP",
+              required=True,
+              callback=validate_minor_release)
 def start_release_detector(minor_release):
     ReleaseDetector(minor_release).start()


### PR DESCRIPTION
```
$ oarctl start-release-detector
Please input the minor version of OCP: 4.12
2024-08-12T09:54:21Z: INFO: latest z-stream version: 4.12.62
2024-08-12T09:54:21Z: INFO: latest stable version: 4.12.62
2024-08-12T09:54:21Z: INFO: no new z-stream release found
```