### PR TITLE
Fix job metadata not found issue

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -696,6 +696,11 @@ class TestResultAggregator():
                     # if it's true, the job result will not be used to determine build is QE accepted
                     job_metadata = self.job_registry.get_test_job(
                         release, nightly, job_result.job_name)
+                    # if job definition is removed from job registry, skip this job and continue
+                    if not job_metadata:
+                        logger.warning(
+                            f"skip aggreation for job run of {job_result.job_name}")
+                        continue
 
                     # if first job is failed and it's not optional we will start to trigger retry jobs
                     # according to `retries` attribute defined in job registry


### PR DESCRIPTION
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-tests-master-qe-release-gate-test/1829100491833872384/artifacts/qe-release-gate-test/release-qe-tests/build-log.txt

check if job metadata not found in job registry, if yes, skip aggregation for the job. 
```
2024-08-29T18:50:20Z: INFO: Cannot find test job periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-aws-ipi-private-fips-f4-disasterrecovery in 4.16 definition
2024-08-29T18:50:20Z: INFO: skip aggreation for job run of periodic-ci-openshift-openshift-tests-private-release-4.16-amd64-nightly-aws-ipi-private-fips-f4-disasterrecovery
```