### PR TITLE
add auto release test result dashboard

### DIFF
--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -1,0 +1,138 @@
+import streamlit as st
+import pandas as pd
+import os
+import json
+from github import Github, Auth
+
+# Define the github access variables
+repository_owner = 'openshift'
+repository_name = 'release-tests'
+directory_path = '_releases'
+branch_name = 'record'
+
+# Read the GitHub token from a system environment variable
+github_token = os.environ.get('GITHUB_TOKEN')
+if not github_token:
+    st.warning("Oops, ENV VAR GITHUB_TOKEN NOT FOUND")
+    st.stop()
+
+
+# Create a GitHub instance with the token
+gh = Github(auth=Auth.Token(github_token))
+
+# Get the repository object
+repo = gh.get_repo(f'{repository_owner}/{repository_name}')
+
+# Get the contents of the specified directory
+directory_contents = repo.get_contents(path=directory_path, ref=branch_name)
+
+
+def get_col_state(file_content):
+    """
+    Get job state: Accepted, Rejected, Pending
+    """
+    build = file_content['build']['name']
+    if 'accepted' in file_content:
+        accepted = 'Accepted' if file_content['accepted'] else 'Rejected'
+    else:
+        accepted = 'Pending'
+
+    return accepted
+
+
+def get_col_test_summary(file_content):
+    """
+    Get test summary for single job
+    S: success, 1 or 2 successful jobs (including 2 retried jobs)
+    F: failure
+    WIP: pending
+    """
+    job_summaries = []
+    job_links = []
+    job_result = file_content['result']
+    for job in job_result:
+        results = []
+        first_job = job['firstJob']
+        if 'jobState' not in first_job:
+            # it means the job is just triggered, skip this file
+            continue
+        results.append(first_job['jobState'])
+        job_links.append(first_job['jobURL'])
+        if 'retriedJobs' in job:
+            for retried_job in job['retriedJobs']:
+                if 'jobState' not in retried_job:
+                    continue
+                results.append(retried_job['jobState'])
+                job_links.append(retried_job['jobURL'])
+
+        if 'pending' in results:
+            job_summaries.append('WIP')
+        else:
+            if len(results) == 1 and results.count('success') == 1:
+                job_summaries.append('S')
+            elif len(results) == 3 and results.count('success') == 2:
+                job_summaries.append('S')
+            else:
+                job_summaries.append('F')
+
+    return job_summaries, job_links
+
+
+@st.dialog("Links")
+def dialog_with_links(links: list[str]):
+    for link in links:
+        st.link_button(link.removeprefix(
+            'https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/'), url=link)
+
+
+@st.cache_data
+def load_test_results(release='4.12'):
+    table_data = []
+    for file in directory_contents:
+        if file.name.startswith('ocp-test-result') and release in file.name:
+            try:
+                file_content = json.loads(file.decoded_content.decode('utf-8'))
+                job_summary, job_links = get_col_test_summary(file_content)
+                table_data.append(
+                    {'Build': file.html_url,
+                     'State': get_col_state(file_content),
+                     'Test Result Summary': job_summary,
+                     "Prow Jobs": job_links
+                     })
+            except json.JSONDecodeError:
+                # don't need to handle the parsing error
+                pass
+
+    return pd.DataFrame(table_data)
+
+
+# start to write page elements
+st.set_page_config(layout='wide')
+st.markdown("<h2 style='text-align: center; color: black;'>Auto Release Test Results</h2>",
+            unsafe_allow_html=True)
+# define a select box to choose minor release, don't load all the test results together
+release = st.selectbox(
+    'Choose minor release',
+    ("4.12", "4.16")
+)
+# load test results and create dataframe
+df = load_test_results(release)
+event = st.dataframe(
+    df,
+    column_config={
+        "Build": st.column_config.LinkColumn(
+            display_text=r"https://github\.com/openshift/release-tests/blob/record/_releases/ocp-test-result-(\d.*\d+)-",
+        ),
+        "Prow Jobs": None
+    },
+    hide_index=True,
+    height=1000,
+    use_container_width=True,
+    selection_mode='single-row',
+    on_select='rerun'
+)
+
+# select event handler
+if row := event['selection']['rows']:
+    links = df.iloc[row]['Prow Jobs'].values[0]
+    dialog_with_links(links)


### PR DESCRIPTION
- add webUI tool to list automated-release test results for different minor releases
- by default, release is 4.12
- use can choose other supported release in select box
- test results will be cached, web page load time is a bit longer at the first time
- configure the selection mode of dataframe as single row, when select the row, will show dialog with all prow job links

<pre>
<img width="804" alt="image" src="https://github.com/user-attachments/assets/4b766304-2913-4a4f-808f-de9238f48929">
</pre>
<pre>
<img width="799" alt="image" src="https://github.com/user-attachments/assets/7616fb4f-4d5d-4fae-8739-8c34629d4ede">
</pre>

Usage: 
- setup steramlit env 
```
pip install streamlit
```
- export env var
```
export GITHUB_TOKEN=xxx
```
- start server
```
 streamlit run auto_release_test_dashboard.py
```