### PR TITLE
OCPQE-25622 validate required option implicitly

### DIFF
--- a/oar/README.md
+++ b/oar/README.md
@@ -54,7 +54,7 @@ Commands:
 ```
 ### Sub command help
 ```
-$ oar -r $release-version $sub-cmd -h
+$ oar $sub-cmd -h
 ```
 ### Examples
 - Common functions

--- a/oar/cli/cmd_group.py
+++ b/oar/cli/cmd_group.py
@@ -38,7 +38,7 @@ def print_version(ctx, param, value):
     expose_value=False,
     is_eager=True,
 )
-@click.option("-r", "--release", help="z-stream releaes version", required=True)
+@click.option("-r", "--release", help="z-stream releaes version")
 @click.option("-v", "--debug", help="enable debug logging", is_flag=True, default=False)
 def cli(ctx, release, debug):
     util.init_logging(logging.DEBUG if debug else logging.INFO)
@@ -48,6 +48,10 @@ def cli(ctx, release, debug):
             is_help = True
             break
     if not is_help:
+        if not release:
+            raise click.MissingParameter(
+                "-r/--release is required", param_type='option')
+
         cs = ConfigStore(release)
         ctx.ensure_object(dict)
         ctx.obj["cs"] = cs


### PR DESCRIPTION
when required option is missed, raise error
```console
$ oar update-bug-list
Usage: oar [OPTIONS] COMMAND [ARGS]...
Try 'oar -h' for help.

Error: Missing option. -r/--release is required
```
option release is not required when getting usage of sub-cmd
```console
$ oar update-bug-list -h                                                                                                                                                                                          2 ↵
Usage: oar update-bug-list [OPTIONS]

  Update bug status listed in report, update existing bug status and append
  new ON_QA bug

Options:
  --notify / --no-notify  Send notification to bug owner, default value is
                          true
  -h, --help              Show this message and exit.
```