### PR TITLE
OCPQE-25667 check metadata ad when call stage pipeline job

### DIFF
--- a/oar/core/jenkins.py
+++ b/oar/core/jenkins.py
@@ -16,7 +16,7 @@ class JenkinsHelper:
     def __init__(self, cs: ConfigStore):
         self._cs = cs
         self.version = util.get_y_release(self._cs.release)
-        self.metadata_ad = self._cs.get_advisories()["metadata"]
+        self.metadata_ad = self._cs.get_advisories().get("metadata")
         # get string errata_numbers like: 115076 115075 115077 115074 115078
         self.errata_numbers = " ".join(
             [str(i) for i in [val for val in self._cs.get_advisories().values()]]
@@ -28,6 +28,9 @@ class JenkinsHelper:
 
     def call_stage_job(self):
         try:
+            if not self.metadata_ad:
+                raise JenkinsException("metadata advisory not found")
+
             build_url = self.call_build_job(
                 JENKINS_JOB_STAGE_PIPELINE, self.pull_spec)
         except JenkinsException as ej:


### PR DESCRIPTION
```
$ oar -r 4.12.66 stage-testing
2024-09-17T15:57:21Z: INFO: job id is not set, will trigger stage testing
2024-09-17T15:57:26Z: ERROR: trigger stage pipeline job failed
Traceback (most recent call last):
  File "/Users/rio.liu/coderepo/release-tests/oar/core/jenkins.py", line 32, in call_stage_job
    raise JenkinsException("metadata advisory not found")
jenkins.JenkinsException: metadata advisory not found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/cmd_stage_testing.py", line 44, in stage_testing
    build_url = jh.call_stage_job()
                ^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/core/jenkins.py", line 37, in call_stage_job
    raise JenkinsHelperException(
oar.core.exceptions.JenkinsHelperException: call stage pipeline job failed
Traceback (most recent call last):
  File "/Users/rio.liu/coderepo/release-tests/oar/core/jenkins.py", line 32, in call_stage_job
    raise JenkinsException("metadata advisory not found")
jenkins.JenkinsException: metadata advisory not found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/rio.liu/.local/bin/oar", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/__main__.py", line 6, in main
    cli(obj={})
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/.local/pipx/venvs/oar/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/cli/cmd_stage_testing.py", line 44, in stage_testing
    build_url = jh.call_stage_job()
                ^^^^^^^^^^^^^^^^^^^
  File "/Users/rio.liu/coderepo/release-tests/oar/core/jenkins.py", line 37, in call_stage_job
    raise JenkinsHelperException(
oar.core.exceptions.JenkinsHelperException: call stage pipeline job failed
```