### PR TITLE
OCPQE-26054 refine logic for jira api limit handler

### DIFF
--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -33,7 +33,7 @@ class JiraManager:
                 raise JiraException("cannot talk to jira server") from je
 
         self._req_count = 0
-        self._req_limit = 3
+        self._req_limit = 2
 
     def get_issue(self, key):
         """
@@ -49,7 +49,7 @@ class JiraManager:
             issue = self._svc.issue(key)
             self._req_count += 1
             if self._req_count == self._req_limit:
-                time.sleep(1)
+                time.sleep(1.75)
                 self._req_count = 0
         except JIRAError as je:
             if je.status_code == 403:


### PR DESCRIPTION
for y stream release, like 4.17.0 there are hundreds of bugs attached to the advisories. jira manager needs to check them all and filter all the ONQA bugs. but it will hit jira api limit error. now jira will not send status code 429 and corresponding headers for retry. it will send 401 code back to the client. so we need to handle this case in our code, sleep for a while (in this case 1.75 secs) when specific number of jira issues are processed