### PR TITLE
handle 403 error when iterate jira issues

### DIFF
--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -3,8 +3,7 @@ import os
 import re
 import logging
 import oar.core.util as util
-from oar.core.exceptions import WorksheetException, WorksheetExistsException
-from oar.core.exceptions import JiraUnauthorizedException
+from oar.core.exceptions import WorksheetException, WorksheetExistsException, JiraUnauthorizedException
 from oar.core.configstore import ConfigStore
 from oar.core.const import *
 from oar.core.advisory import AdvisoryManager
@@ -384,6 +383,8 @@ class TestReport:
                     logger.info(f"bug {bug_key} is dropped")
                 else:
                     logger.info(f"bug status of {bug_key} is not changed")
+            except JiraUnauthorizedException:
+                pass
             except Exception as e:
                 raise WorksheetException(
                     f"update bug {bug_key} status failed") from e


### PR DESCRIPTION
when iterate bugs in report, if we get 403 error, don't terminate the process. catch the exception and do nothing, i.e. skip the issued bug (it's possible that jira bot does not have permission to access restricted bugs)