### PR TITLE
integrate LLM with slack bot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "artcommon@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=artcommon",
     "pyartcd@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=pyartcd",
     "rh-elliott@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=elliott",
-    "rh-doozer@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=doozer"
+    "rh-doozer@git+https://github.com/openshift-eng/art-tools.git@main#subdirectory=doozer",
+    "langchain-community"
 ]
 
 [project.scripts]

--- a/tools/slack_message_receiver.py
+++ b/tools/slack_message_receiver.py
@@ -3,6 +3,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 from slack_sdk.socket_mode import SocketModeClient
+from langchain_community.llms.vllm import VLLMOpenAI
 import os
 import logging
 import re
@@ -49,6 +50,31 @@ def is_oar_related_message(message):
     return message.startswith("oar") or message.startswith("oarctl") or re.search("^<\@.*>\ oar\ ", message) or re.search("^<\@.*>\ oarctl\ ", message)
 
 
+def send_prompt_to_ai_model(prompt):
+    """
+    Send prompt message to LLM model and return the answer
+    We only support OpenAI-compatible API
+    """
+    model_api_base = os.environ.get("MODEL_API_BASE")
+    model_api_key = os.environ.get("MODEL_API_KEY")
+    model_api_name = os.environ.get("MODEL_API_NAME")
+
+    if not model_api_base or not model_api_key or not model_api_name:
+        logger.warning(
+            "environment variables MODEL_API_BASE/MODEL_API_KEY/MODEL_API_NAME are not defined")
+        return None
+
+    if prompt:
+        llm = VLLMOpenAI(
+            openai_api_key=model_api_key,
+            openai_api_base=f"{model_api_base}/v1",
+            model_name=model_api_name,
+        )
+        return llm.invoke(prompt)
+
+    return None
+
+
 def process(client: SocketModeClient, req: SocketModeRequest):
     # Acknowledge the request anyway
     response = SocketModeResponse(envelope_id=req.envelope_id)
@@ -91,6 +117,16 @@ def process(client: SocketModeClient, req: SocketModeRequest):
                         channel=channel_id,
                         thread_ts=thread_ts,
                         text=f"```{result.stdout}```")
+            else:
+                # forward message as prompt to LLM, this feature is optional
+                # if required system environment variables are not defined
+                # API call with AI model is disabled, none will be returned
+                answer = send_prompt_to_ai_model(message)
+                if answer:
+                    client.web_client.chat_postMessage(
+                        channel=channel_id,
+                        thread_ts=thread_ts,
+                        text=answer)
 
 
 # Add a new listener to receive messages from Slack


### PR DESCRIPTION
currently slack app only support oar related message, for other messages, they will be dropped, if we can integrate with LLM API service with slack app, the user can send any message to this slack app. logic is like if the message does not start with`oar/oarctl`, forward this message to LLM API service. OS environment variables are required to enable this feature
```
# base url of LLM API service
MODEL_API_BASE=
# LLM API service key
MODEL_API_KEY
# API model name
MODEL_API_NAME
```
 currently we only support OpenAI compatible API service