### PR TITLE
OCPERT-4 cover upgrade b/w patch releases for 4.15

### DIFF
--- a/_releases/ocp-4.15-test-jobs-amd64.json
+++ b/_releases/ocp-4.15-test-jobs-amd64.json
@@ -14,7 +14,7 @@
       "upgrade": true
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-stable-4.15-upgrade-from-stable-4.14-aws-ipi-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-stable-4.15-upgrade-from-stable-4.15-aws-ipi-f999",
       "upgrade": true
     }
   ],


### PR DESCRIPTION
cover upgrade path b/w patch releases for 4.15 nightly, for nightly we need 2 jobs to cover upgrade path b/w minor and patch releases