### PR TITLE
OCPERT-26 fix keyerror when remove attr from dict

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -859,8 +859,8 @@ class TestResultAggregator():
                         job_run["jobID"] = new_job_id
                         break
                 # delete attr `aggregated` and `accepted`
-                json_data.pop("aggregated")
-                json_data.pop("accepted")
+                json_data.pop("aggregated", None)
+                json_data.pop("accepted", None)
                 self.release_test_record.push_file(
                     data=json_data, path=file_path)
             else:


### PR DESCRIPTION
fix issue when update same file multiple times, add default value `None` for `pop` func
```
  File "/Users/rio.liu/coderepo/release-tests/prow/job/controller.py", line 923, in update_retried_job_run
    TestResultAggregator(arch).update_retried_job_run(
  File "/Users/rio.liu/coderepo/release-tests/prow/job/controller.py", line 862, in update_retried_job_run
    json_data.pop("aggregated")
KeyError: 'aggregated'
```
