### PR TITLE
OCPERT-31 add new cmd to trigger jobs manually

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -922,12 +922,12 @@ def start_controller(release, nightly, trigger_prow_job, arch):
 
 
 @click.command
-@click.option("-r", "--release", help="y-stream release number e.g. 4.15", required=True)
-@click.option("--nightly/--no-nightly", help="target build is nightly or stable build, default is nightly", default=True)
 @click.option("--build", help="build version e.g. 4.16.20", required=True)
 @click.option("--arch", help="architecture used to filter accepted build", default=Architectures.AMD64, type=click.Choice(Architectures.VALID_ARCHS))
-def trigger_jobs_for_build(release, nightly, build, arch):
+def trigger_jobs_for_build(build, arch):
     validate_required_info(REQUIRED_ENV_VARS_FOR_CONTROLLER)
+    release = build[:4]
+    nightly = "nightly" in build
     controller = JobController(release, nightly, True, arch)
     build_obj = controller.get_build(build)
     if build_obj is None:


### PR DESCRIPTION
```
jobctl trigger-jobs-for-build --help
Usage: jobctl trigger-jobs-for-build [OPTIONS]

Options:
  --build TEXT                    build version e.g. 4.16.20  [required]
  --arch [amd64|arm64|multi|ppc64le|s390x]
                                  architecture used to filter accepted build
  --help                          Show this message and exit.
```
negative case build not found
```
jobctl trigger-jobs-for-build --build 4.15.80
2024-12-06T14:31:57Z: INFO: Initializing test job registry ...
2024-12-06T14:31:59Z: INFO: Test job definitions for 4.12-amd64 is initialized
2024-12-06T14:31:59Z: INFO: Test job definitions for 4.13-amd64 is initialized
2024-12-06T14:32:00Z: INFO: Test job definitions for 4.14-amd64 is initialized
2024-12-06T14:32:01Z: INFO: Test job definitions for 4.15-amd64 is initialized
2024-12-06T14:32:01Z: INFO: Test job definitions for 4.16-amd64 is initialized
2024-12-06T14:32:01Z: INFO: Test job registry is initialized
Usage: jobctl trigger-jobs-for-build [OPTIONS]
Try 'jobctl trigger-jobs-for-build --help' for help.

Error: Invalid value: build 4.15.80 does not exist, please double check
```
postive
```
 jobctl trigger-jobs-for-build --build 4.14.0-0.nightly-2024-12-05-023928
2024-12-06T14:54:25Z: INFO: Initializing test job registry ...
2024-12-06T14:54:27Z: INFO: Test job definitions for 4.12-amd64 is initialized
2024-12-06T14:54:28Z: INFO: Test job definitions for 4.13-amd64 is initialized
2024-12-06T14:54:28Z: INFO: Test job definitions for 4.14-amd64 is initialized
2024-12-06T14:54:29Z: INFO: Test job definitions for 4.15-amd64 is initialized
2024-12-06T14:54:30Z: INFO: Test job definitions for 4.16-amd64 is initialized
2024-12-06T14:54:30Z: INFO: Test job registry is initialized
2024-12-06T14:54:32Z: INFO: start to trigger prow jobs for build:
{
  "name": "4.14.0-0.nightly-2024-12-05-023928",
  "phase": "Accepted",
  "pullSpec": "registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928",
  "downloadURL": "https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.14.0-0.nightly-2024-12-05-023928"
}
2024-12-06T14:54:32Z: INFO: Start to trigger prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-f999 ...

{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928'}}}
Returned job id: 1ef021af-7de9-4002-a118-a7d5323d88d6
periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-f999 registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928 1ef021af-7de9-4002-a118-a7d5323d88d6 2024-12-06T06:54:33Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-f999/1864926386632790016 pending
Done.

2024-12-06T14:54:39Z: INFO: Triggered prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-f999 with build 4.14.0-0.nightly-2024-12-05-023928, job id=1ef021af-7de9-4002-a118-a7d5323d88d6

2024-12-06T14:54:39Z: INFO: Start to trigger prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-azure-ipi-f999 ...

{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928'}}}
Returned job id: ca45f471-896e-41dd-93c6-82596db51324
periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-azure-ipi-f999 registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928 ca45f471-896e-41dd-93c6-82596db51324 2024-12-06T06:54:39Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-azure-ipi-f999/1864926412033495040 pending
Done.

2024-12-06T14:54:45Z: INFO: Triggered prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-azure-ipi-f999 with build 4.14.0-0.nightly-2024-12-05-023928, job id=ca45f471-896e-41dd-93c6-82596db51324

2024-12-06T14:54:45Z: INFO: Start to trigger prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-gcp-ipi-f999 ...

{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928'}}}
Returned job id: 89e1372b-fe82-4c4e-807f-0c11167e649a
periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-gcp-ipi-f999 registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928 89e1372b-fe82-4c4e-807f-0c11167e649a 2024-12-06T06:54:45Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-gcp-ipi-f999/1864926437216096256 pending
Done.

2024-12-06T14:54:51Z: INFO: Triggered prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-gcp-ipi-f999 with build 4.14.0-0.nightly-2024-12-05-023928, job id=89e1372b-fe82-4c4e-807f-0c11167e649a

2024-12-06T14:54:51Z: INFO: Start to trigger prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.13-gcp-ipi-f999 ...

{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_TARGET': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928'}}}
Returned job id: 239c8eca-d3a3-470a-902e-06c5d72b3be3
periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.13-gcp-ipi-f999 None 239c8eca-d3a3-470a-902e-06c5d72b3be3 2024-12-06T06:54:51Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.13-gcp-ipi-f999/1864926462159622144 pending
Done.

2024-12-06T14:54:57Z: INFO: Triggered prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.13-gcp-ipi-f999 with build 4.14.0-0.nightly-2024-12-05-023928, job id=239c8eca-d3a3-470a-902e-06c5d72b3be3

2024-12-06T14:54:57Z: INFO: Start to trigger prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.14-aws-ipi-f999 ...

2024-12-06T14:54:58Z: INFO: File _releases/ocp-latest-4.14-stable-amd64.json can be found
{'job_execution_type': '1', 'pod_spec_options': {'envs': {'RELEASE_IMAGE_LATEST': 'quay.io/openshift-release-dev/ocp-release:4.14.42-x86_64', 'RELEASE_IMAGE_TARGET': 'registry.ci.openshift.org/ocp/release:4.14.0-0.nightly-2024-12-05-023928'}}}
Returned job id: 3e1b8867-06f8-446d-a763-b405d7a28360
periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.14-aws-ipi-f999 None 3e1b8867-06f8-446d-a763-b405d7a28360 2024-12-06T06:54:59Z https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.14-aws-ipi-f999/1864926492396359680 pending
Done.

2024-12-06T14:55:04Z: INFO: Triggered prow job periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.14-aws-ipi-f999 with build 4.14.0-0.nightly-2024-12-05-023928, job id=3e1b8867-06f8-446d-a763-b405d7a28360

2024-12-06T14:55:05Z: INFO: File _releases/ocp-test-result-4.14.0-0.nightly-2024-12-05-023928-amd64.json not found
2024-12-06T14:55:05Z: INFO: Creating file _releases/ocp-test-result-4.14.0-0.nightly-2024-12-05-023928-amd64.json
2024-12-06T14:55:06Z: INFO: File is created successfully
2024-12-06T14:55:06Z: INFO: Test result of 4.14.0-0.nightly-2024-12-05-023928 is saved to _releases/ocp-test-result-4.14.0-0.nightly-2024-12-05-023928-amd64.json
```