### PR TITLE
OCPERT-6: Enable 4.17 release in Test Results Dashboard

### DIFF
--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -119,7 +119,7 @@ cola, colb = st.columns(2, vertical_alignment='bottom')
 with cola:
     release = st.selectbox(
         'Choose minor release',
-        ("4.12", "4.13", "4.14", "4.15", "4.16")
+        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17")
     )
 # clear cache manually if you want to get latest results
 with colb:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPERT-6