### PR TITLE
Update base image to py3.12-alpine

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -1,8 +1,7 @@
 #FROM registry.access.redhat.com/ubi8/python-39
-FROM python:3.11
-LABEL maintainer="jiazha@redhat.com"
+FROM python:3.12-alpine
+LABEL maintainer="rioliu@redhat.com"
 WORKDIR /usr/src/release-tests
 COPY . .
 RUN pip3 install --upgrade pip && pip3 install cffi
 RUN pip3 install -e ./prow
-ENTRYPOINT ["job"]


### PR DESCRIPTION
new base image is based on python3.12-alpine, it has better performance and smaller size