### PR TITLE
fix syntax warning in py3.12

### DIFF
--- a/prow/job/artifacts.py
+++ b/prow/job/artifacts.py
@@ -22,9 +22,9 @@ class Artifacts():
         self._root_dir = f"logs/{job_name}/{job_run_id}"
 
     def get_junit_files(self):
-        patterns = ['.*\/junit.*import-.*xml',
-                    '.*\/junit.*TEST-features-.*xml',
-                    '.*\/gui_test.*console-cypress.xml']
+        patterns = [r'.*/junit.*import-.*xml',
+                    r'.*/junit.*TEST-features-.*xml',
+                    r'.*/gui_test.*console-cypress.xml']
         return self._gcs.get_files(self._root_dir, patterns)
 
     def get_test_failures_summary(self):


### PR DESCRIPTION
upgraded python runtime to 3.12, there are few syntax warning from regex expression
```
/usr/src/release-tests/prow/job/artifacts.py:25: SyntaxWarning: invalid escape sequence '\/'
  patterns = ['.*\/junit.*import-.*xml',
/usr/src/release-tests/prow/job/artifacts.py:26: SyntaxWarning: invalid escape sequence '\/'
  '.*\/junit.*TEST-features-.*xml',
/usr/src/release-tests/prow/job/artifacts.py:27: SyntaxWarning: invalid escape sequence '\/'
  '.*\/gui_test.*console-cypress.xml']
```
