### PR TITLE
OCPERT-47 Enable auto release jobs for 4.18

### DIFF
--- a/_releases/ocp-4.18-test-jobs-amd64.json
+++ b/_releases/ocp-4.18-test-jobs-amd64.json
@@ -1,0 +1,35 @@
+{
+  "nightly": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-aws-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-azure-ipi-fips-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-gcp-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.17-gcp-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.18-aws-ipi-f999",
+      "upgrade": true
+    }
+  ],
+  "stable": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.17-aws-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.18-azure-ipi-fips-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.18-gcp-ipi-f999",
+      "upgrade": true
+    }
+  ]
+}

--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -119,7 +119,7 @@ cola, colb = st.columns(2, vertical_alignment='bottom')
 with cola:
     release = st.selectbox(
         'Choose minor release',
-        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17")
+        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18")
     )
 # clear cache manually if you want to get latest results
 with colb:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPERT-47

depends on https://github.com/openshift/release/pull/61246