### PR TITLE
OCPERT-62 support candidate build for elliott

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -260,7 +260,7 @@ class AdvisoryManager:
             "--group",
             f"openshift-{util.get_y_release(self._cs.release)}",
             "--assembly",
-            self._cs.release,
+            util.get_release_key(self._cs.release),
             "find-bugs:sweep",
             "--cve-only",
             "--report",


### PR DESCRIPTION
get assembly from release version for elliott cmd, this cmd is used by `check-cve-tracker-bug`