### PR TITLE
OCPERT-44 skip kernel tag checking if no rhcos nvr found in advisory builds

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -773,18 +773,22 @@ class Advisory(Erratum):
             return False
         #Get rhcos nvr from image advisory build
         build_response = self._get(f"/api/v1/erratum/{self.errata_id}/builds")
-        rhos_nvr = None
+        rhcos_nvr = None
         for value in build_response.values():
             for build in value['builds']:
                 for build_name in build.keys():
                     if build_name.startswith("rhcos-x86"):
-                        rhos_nvr = build_name
+                        rhcos_nvr = build_name
                         break
-        logger.info(f"RHCOS nvr is {rhos_nvr}")
+        logger.info(f"RHCOS nvr is {rhcos_nvr}")
+        # if there is no rhcos build found, skip checking
+        if rhcos_nvr is None:
+            logger.warning("No RHCOS nvr found, skip kernel tag checking")
+            return False
         #Download the commit metadata based on info in nvr.
-        rhos_nvr_url = re.sub(r"-([\d.]+)-(\d+)$", r"/\1/\2", rhos_nvr)
-        rhos_nvr_url_full = "https://download.eng.bos.redhat.com/brewroot/packages/"+rhos_nvr_url+"/metadata.json"
-        rhos_meta_data_full = self._get(rhos_nvr_url_full)
+        rhcos_nvr_url = re.sub(r"-([\d.]+)-(\d+)$", r"/\1/\2", rhcos_nvr)
+        rhcos_nvr_url_full = "https://download.eng.bos.redhat.com/brewroot/packages/"+rhcos_nvr_url+"/metadata.json"
+        rhos_meta_data_full = self._get(rhcos_nvr_url_full)
         kernel_build = [
             f"{comp['name']}-{comp['version']}-{comp['release']}"
             for entry in rhos_meta_data_full['output']

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -72,3 +72,4 @@ class TestAdvisoryManager(unittest.TestCase):
     def test_kernel_tag(self):
         self.assertTrue(Advisory(errata_id=144853, impetus='image').check_kernel_tag())
         self.assertFalse(Advisory(errata_id=144854, impetus='metadata').check_kernel_tag())
+        self.assertFalse(Advisory(errata_id=146595, impetus='image').check_kernel_tag())


### PR DESCRIPTION

```console
$ py -m unittest tests.test_advisory.TestAdvisoryManager.test_kernel_tag
No RHCOS nvr found, skip kernel tag checking
.
----------------------------------------------------------------------
Ran 1 test in 39.410s

OK
```