### PR TITLE
OCPERT-69 Send notification of unhealthy container to ERT member instead of artist

### DIFF
--- a/oar/core/notification.py
+++ b/oar/core/notification.py
@@ -514,7 +514,9 @@ class MessageHelper:
             str: slack message
         """
         gid = self.sc.get_group_id_by_name(
-            self.cs.get_slack_user_group_from_contact_by_id("ert")
+            self.cs.get_slack_user_group_from_contact(
+                "qe-release", util.get_y_release(self.cs.release)
+            )
         )
 
         message = f"Hello {gid}, Found unhealthy advisories, please check if this is a known issue before ping artist in channel #forum-ocp-release, thanks\n"

--- a/oar/core/notification.py
+++ b/oar/core/notification.py
@@ -514,10 +514,10 @@ class MessageHelper:
             str: slack message
         """
         gid = self.sc.get_group_id_by_name(
-            self.cs.get_slack_user_group_from_contact_by_id("art")
+            self.cs.get_slack_user_group_from_contact_by_id("ert")
         )
 
-        message = f"Hello {gid}, Found unhealthy advisories, could you please take a look, thanks\n"
+        message = f"Hello {gid}, Found unhealthy advisories, please check if this is a known issue before ping artist in channel #forum-ocp-release, thanks\n"
 
         for ua in unhealthy_advisories:
             message += f"Advisory {util.get_advisory_link(ua['errata_id'])} has grade {ua['ad_grade']} with unhealthy builds:\n"

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -5,6 +5,7 @@ from oar.core.notification import NotificationManager
 from oar.core.configstore import ConfigStore
 from oar.core.worksheet import WorksheetManager
 from oar.core.worksheet import TestReport
+import oar.core.util as util
 
 logging.basicConfig(
     level=logging.DEBUG,  # Set the minimum log level to DEBUG
@@ -58,3 +59,11 @@ class TestNotificationManager(unittest.TestCase):
         wm = WorksheetManager(cs)
         nm = NotificationManager(cs)
         nm.share_new_report(wm.get_test_report())
+
+    def test_get_qe_release_slack(self):
+        gid = self.nm.sc.get_group_id_by_name(
+            self.cs.get_slack_user_group_from_contact(
+                "qe-release", util.get_y_release(self.cs.release)
+            )
+        )
+        self.assertTrue(gid.startswith("<!subteam"))


### PR DESCRIPTION
python -m unittest tests.test_notification.TestNotificationManager.test_get_qe_release_slack
...
2025-03-12 09:51:48,590 - DEBUG - Slack group id of 4.13-qe-leads is added to runtime cache
.
----------------------------------------------------------------------
Ran 1 test in 5.114s

OK