### PR TITLE
OCPERT-56 OAR Fix wrong data types in docstring

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -31,7 +31,7 @@ class AdvisoryManager:
         Get all advisories
 
         Returns:
-             Advisory (list): all advisory wrappers
+            list[Advisory]: all advisory wrappers
         """
         ads = []
         for k, v in self._cs.get_advisories().items():
@@ -169,13 +169,10 @@ class AdvisoryManager:
         Change advisories status, e.g. REL_PREP
 
         Args:
-            status (str, optional): status used to update. Defaults to REL_PREP.
+            target_status (str, optional): status used to update. Defaults to REL_PREP.
 
         Raises:
             AdvisoryException: error when update advisory status
-
-        Returns:
-            _type_: _description_
         """
         try:
             ads = self.get_advisories()
@@ -237,7 +234,7 @@ class AdvisoryManager:
             AdvisoryException: error when invoke elliott cmd
 
         Returns:
-            json: missed CVE tracker bugs
+            list: CVE tracker bugs not found in RHSA advisories
         """
         cmd = [
             "elliott",
@@ -287,7 +284,7 @@ class AdvisoryManager:
 
     def get_doc_prodsec_approved_ads(self):
         """
-        get Docs and product security approved advisories
+        Get Docs and product security approved advisories
         """
         try:
             approved_doc_ads = []
@@ -393,12 +390,12 @@ class Advisory(Erratum):
         logger.info(
             f"advisory {self.errata_id} state is updated to {state.upper()}")
 
-    def remove_bugs(self, bug_list: list):
+    def remove_bugs(self, bug_list: list[str]):
         """
         Drop bugs from advisory
 
         Args:
-            bugs (list): bug list
+            bug_list (list[str]): bug list
         """
         self.removeJIRAIssues(bug_list)
         need_refresh = self.commit()
@@ -545,6 +542,7 @@ class Advisory(Erratum):
     def is_doc_approved(self):
         """
         Check if doc is approved for an advisory
+
         Returns:
             bool: True if doc for an advisory is approved, otherwise False
         """
@@ -553,6 +551,7 @@ class Advisory(Erratum):
     def is_prodsec_approved(self):
         """
         Check if prodsec is approved for an advisory
+
         Returns:
             bool: True if prodsec is approved, otherwise False
         """
@@ -561,6 +560,7 @@ class Advisory(Erratum):
     def is_doc_requested(self):
         """
         Check if doc for an advisory is requested
+
         Returns:
             bool: True if doc for an advisory is requested, otherwise False
         """
@@ -569,14 +569,15 @@ class Advisory(Erratum):
     def is_prodsec_requested(self):
         """
         Check if prodsec for an advisory is requested
+
         Returns:
-        bool: False if prodsec for an advisory is requested, otherwise False
+            bool: False if prodsec for an advisory is requested, otherwise False
         """
         return self.get_erratum_data()["security_approved"] == False
 
     def request_doc_approval(self):
         """
-        send doc approval request for an advisory
+        Send doc approval request for an advisory
         """
         pdata = {"advisory[text_ready]": 1}
         url = "/api/v1/erratum/%i" % self.errata_id
@@ -585,7 +586,7 @@ class Advisory(Erratum):
 
     def request_prodsec_approval(self):
         """
-        send product security approval request for an advisory
+        Send product security approval request for an advisory
         """
         pdata = {"advisory[security_approved]": False}
         url = "/api/v1/erratum/%i" % self.errata_id

--- a/oar/core/configstore.py
+++ b/oar/core/configstore.py
@@ -304,7 +304,7 @@ class ConfigStore:
         we should get advisories from parent assembly i.e. 4.14.0
 
         Args:
-            keypath (_str_): attribute key path e.g. group/advisories!
+            keypath (str): attribute key path e.g. group/advisories!
         """
         attr_val = None
         basis = self._assembly["basis"]
@@ -327,8 +327,8 @@ class ConfigStore:
         e.g. releases/4.14.1/assembly
 
         Args:
-            json (_dict_): json object
-            path (_str_): attribute path based on current json object
+            json (dict): json object
+            path (str): attribute path based on current json object
         """
         tmp = json
         if tmp:

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -132,10 +132,10 @@ class JiraManager:
         Get jira subtasks by parent key
 
         Args:
-            partent_key (str): parent issue key
+            parent_key (str): parent issue key
 
         Returns:
-            JiraIssue (list): jira subtask list
+            list[JiraIssue]: jira subtask list
         """
         subtasks = []
         if not parent_key:
@@ -194,6 +194,7 @@ class JiraManager:
         Add comment for jira issue
 
         Args:
+            key (str): jira issue key
             comment (str): description
         """
         if key and comment:
@@ -387,7 +388,7 @@ class JiraIssue:
 
     def is_qe_subtask(self):
         """
-        check whether the issue is QE subtask.
+        Check whether the issue is QE subtask.
         """
         return self.get_summary() in JIRA_QE_TASK_SUMMARIES
 

--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -266,7 +266,7 @@ class TestReport:
 
     def is_task_pass(self, label):
         """
-        Util func to check whether task is pass
+        Util func to check whether task status is 'Pass'
 
         Args:
             label (str): cell label of different tasks
@@ -275,7 +275,7 @@ class TestReport:
 
     def is_task_fail(self, label):
         """
-        Util func to check whether task is fail
+        Util func to check whether task status is 'Fail'
 
         Args:
             label (str): cell label of different tasks
@@ -309,12 +309,12 @@ class TestReport:
         """
         return OVERALL_STATUS_RED == self.get_overall_status()
 
-    def generate_bug_list(self, jira_issues: list):
+    def generate_bug_list(self, jira_issues: list[str]):
         """
         Generate bug list of on_qa bugs
 
         Args:
-            jira_issues (list): jira issue keys from advisories
+            jira_issues (list[str]): jira issue keys from advisories
         """
         logger.info("waiting for the bugs to be verified to update in sheet")
         jm = JiraManager(self._cs)
@@ -354,8 +354,8 @@ class TestReport:
 
     def update_bug_list(self, jira_issues: list):
         """
-        update existing bug status in report
-        append new ON_QA bugs
+        Update existing bug status in report
+        Append new ON_QA bugs
 
         Args:
             jira_issues (list): updated jira issues
@@ -468,7 +468,7 @@ class TestReport:
 
     def append_missed_cve_tracker_bugs(self, cve_tracker_bugs):
         """
-        Append missed cve tracker bugs
+        Append missed CVE tracker bugs
         """
         if len(cve_tracker_bugs) == 0:
             logger.warning("no cve bugs found, won't update report")


### PR DESCRIPTION

[OAR Fix wrong data types in docstring](https://issues.redhat.com/browse/OCPERT-56) in https://github.com/openshift/release-tests repository.

Details:
OAR tool docstring use wrong data types in docstring. For example [] instead of list.

Update all docstrings in OAR tool to use correct OAR types.

Scope:
OAR tool only.
It is not a goal to provide new docstrings, or add types to actual code.