### PR TITLE
OCPERT-73 promote disruptive jobs as blocking job

### DIFF
--- a/_releases/ocp-4.14-test-jobs-amd64.json
+++ b/_releases/ocp-4.14-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.14-automated-release-stable-4.14-upgrade-from-stable-4.13-gcp-ipi-f999",

--- a/_releases/ocp-4.15-test-jobs-amd64.json
+++ b/_releases/ocp-4.15-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.15-automated-release-stable-4.15-upgrade-from-stable-4.14-gcp-ipi-f999",

--- a/_releases/ocp-4.16-test-jobs-amd64.json
+++ b/_releases/ocp-4.16-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.16-automated-release-stable-4.16-upgrade-from-stable-4.15-gcp-ipi-f999",

--- a/_releases/ocp-4.17-test-jobs-amd64.json
+++ b/_releases/ocp-4.17-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.17-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.17-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.17-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.17-automated-release-stable-4.17-upgrade-from-stable-4.16-gcp-ipi-f999",

--- a/_releases/ocp-4.18-test-jobs-amd64.json
+++ b/_releases/ocp-4.18-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.18-automated-release-stable-4.18-upgrade-from-stable-4.17-gcp-ipi-f999",

--- a/_releases/ocp-4.19-test-jobs-amd64.json
+++ b/_releases/ocp-4.19-test-jobs-amd64.json
@@ -10,8 +10,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-gcp-ipi-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-aws-ipi-disruptive-f999",
-      "optional": true
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-aws-ipi-disruptive-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-stable-4.19-upgrade-from-stable-4.18-gcp-ipi-f999",


### PR DESCRIPTION
according to test results in past few weeks. the disruptive jobs are stable enough, so promote these jobs as blocking job