### PR TITLE
OCPERT-59 OAR Assess must-verify issue category and update relevant p…

### DIFF
--- a/oar/README.md
+++ b/oar/README.md
@@ -98,7 +98,7 @@ $ oar -r $release-version stage-testing -n 123
 ```
 $ oar -r $release-version image-signed-check
 ```
-10. This command checks all not verified bugs from advisories. If any bug is `Critical`, `CVE Tracker` or `Customer Case` it is "must-verify" bug. In that case, they need to be confirmed with a bug owner, a Slack notification is sent out. The rest of the bugs are dropped automatically
+10. This command checks all not verified bugs from advisories. If any bug is `Critical`, `CVE Tracker` or `Customer Case`, it is a "high severity" bug. These bugs need to be confirmed with a bug owner, a Slack notification is sent out. The rest of the bugs are dropped automatically
 ```
 $ oar -r $release-version drop-bugs
 ```


### PR DESCRIPTION
…arts

https://issues.redhat.com/browse/OCPERT-59

The logic was updated as part of [OCPERT-51](https://issues.redhat.com/browse/OCPERT-51). This pull-request removes the remaining occurrence of "must-verify" in the repository.