### PR TITLE
remove min-permissions for gcp 4.12 auto release jobs

### DIFF
--- a/_releases/ocp-4.12-test-jobs-amd64.json
+++ b/_releases/ocp-4.12-test-jobs-amd64.json
@@ -7,14 +7,14 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-azure-ipi-fips-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-gcp-ipi-mini-perm-custom-type-f999"
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-gcp-ipi-custom-type-f999"
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-aws-ipi-f999",
       "upgrade": true
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-gcp-ipi-mini-perm-custom-type-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-gcp-ipi-custom-type-f999",
       "upgrade": true
     }
   ],
@@ -24,7 +24,7 @@
       "upgrade": true
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-gcp-ipi-mini-perm-custom-type-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.12-automated-release-stable-4.12-upgrade-from-stable-4.12-gcp-ipi-custom-type-f999",
       "upgrade": true
     },
     {


### PR DESCRIPTION
This was merged https://github.com/openshift/release/pull/63374 and we need to update the test matrix accordingly