### PR TITLE
OCPERT-80 Enhance shipment MR handling and add advisory support back 

### DIFF
--- a/oar/core/configstore.py
+++ b/oar/core/configstore.py
@@ -296,13 +296,30 @@ class ConfigStore:
         return self._local_conf["signature_url"]
 
     def get_shipment_mrs(self):
-        """Get the list of shipment MR URLs from the assembly configuration.
+        """Get shipment MR URLs from assembly config, handling both single and multiple shipments.
 
         Returns:
             list: List of MR URLs (empty list if none found)
         """
-        mrs = self._get_assembly_attr("group/shipments/mrs")
-        return [mr["url"] for mr in mrs] if mrs else []
+        shipments = self._get_assembly_attr("group/shipments")
+        if not shipments:
+            return []
+        if isinstance(shipments, dict):  # Single shipment case
+            return [shipments["url"]]
+        return [s["url"] for s in shipments]  # Multiple shipments case
+
+    def get_advisories(self):
+        """
+        Get advisories info from build data e.g.
+        group:
+            advisories:
+                extras: 113027
+                image: 113026
+                metadata: 113028
+                rpm: 113025
+        """
+
+        return self._get_assembly_attr("group/advisories")
 
     def _get_env_var(self, var):
         """


### PR DESCRIPTION
- Improve `get_shipment_mrs()` to handle both single and multiple shipment cases
- Put `get_advisories()` method back, we still have advisories defined in assembly e.g. microshift  and rpm
- Implement `get_status()` for GitLab MRs to check current state
- Filter MRs to only include opened ones during initialization
- Add better error handling and logging for MR operations

latest data structure change can be found in https://github.com/openshift-eng/art-tools/pull/1546