### PR TITLE
Make advisory urls clickable in the test-report

### DIFF
--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -160,7 +160,7 @@ class TestReport:
         Args:
             ad (str): advisories of current release
         """
-        self._ws.update_acell(LABEL_ADVISORY, ad)
+        self._to_hyperlink(self._ws.update_acell(LABEL_ADVISORY, ad))
 
     def get_advisory_info(self):
         """


### PR DESCRIPTION
JIRA:  https://issues.redhat.com/browse/OCPERT-108
Could you please take a look?