### PR TITLE
OCPERT-119 Fix GitLab client initialization and suppress SSL warnings

### DIFF
--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -303,7 +303,7 @@ class GitLabServer:
         if not self.private_token:
             raise ValueError("No GitLab token provided and GITLAB_TOKEN env var not set")
             
-        self.gl = gitlab.Gitlab(gitlab_url, private_token=self.private_token)
+        self.gl = Gitlab(gitlab_url, private_token=self.private_token)
         
     def get_username_by_email(self, email: str) -> Optional[str]:
         """Query GitLab username by email address

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -1,6 +1,7 @@
 import logging
-from semver.version import Version
+import warnings
 import re
+from semver.version import Version
 
 def is_valid_z_release(version):
     strs = version.split(".")
@@ -42,6 +43,14 @@ def init_logging(log_level=logging.INFO):
         format="%(asctime)s: %(levelname)s: %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%SZ",
         level=log_level,
+    )
+
+    # Suppress specific SSL patching warning
+    warnings.filterwarnings(
+        "ignore",
+        message="Failed to patch SSL settings for unverified requests",
+        category=UserWarning,
+        module="pip_system_certs.wrapt_requests"
     )
 
     loggers = logging.Logger.manager.loggerDict


### PR DESCRIPTION
- Correct GitLab client initialization by using direct `Gitlab` class import instead of `gitlab.Gitlab`
- Add SSL warning suppression for unverified requests in logging setup
- Reorganize imports in util.py for better readability