### PR TITLE
OCPERT-119 Add SSL warning suppression and import warnings module

### DIFF
--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from semver.version import Version
 
 def is_valid_z_release(version):
@@ -46,6 +47,14 @@ def init_logging(log_level=logging.INFO):
         level=log_level,
     )
 
+    # Suppress specific SSL patching warning
+    warnings.filterwarnings(
+        "ignore",
+        message="Failed to patch SSL settings for unverified requests",
+        category=UserWarning,
+        module="pip_system_certs.wrapt_requests"
+    )
+    
     loggers = logging.Logger.manager.loggerDict
     for k in loggers.keys():
         if "requests" in k or "urllib3" in k or "gssapi" in k:


### PR DESCRIPTION
- Import warnings module to handle warning messages
- Add filter to suppress SSL patching warning from pip_system_certs
- Maintain existing logging functionality while reducing noise from known warning