### PR TITLE
OCPERT-97 Add cyborg class

### DIFF
--- a/oar/core/cyborg.py
+++ b/oar/core/cyborg.py
@@ -1,0 +1,49 @@
+from dependency_injector import providers
+from orglib.main import OrgData
+from orglib.container import Container
+from orglib.settings import Settings
+from orglib.org import OrgField
+from orglib.org_models.custom_types import AllowedConfigTypes, AllowedRoleTypes
+
+
+class Cyborg:
+
+    def __init__(self):
+        container = Container()
+        container.settings.override(
+            providers.Singleton(
+                Settings,
+                run_jira_checks=False,
+                run_ldap_checks=False,
+                run_file_checks=False,
+                run_google_group_checks=False,
+                org_git_url_or_path="git@gitlab.cee.redhat.com:hybrid-platforms/org.git"
+            )
+        )
+        container.gc_manager.override(None)
+        container.files_cache.add_kwargs(warm=True)
+        org_data = OrgData(container)
+        self._teams = org_data.query(
+            conditions={
+                OrgField.VISUALIZE_GROUPS.value: "ocp",
+                OrgField.VISUALIZE.value: True,
+                OrgField.TYPE.value: AllowedConfigTypes.team.value,
+            }
+        )
+
+    def get_manager_ids(self, qa_concact_id: str) -> set[str]:
+        return self._get_role_ids(qa_concact_id, AllowedRoleTypes.manager.value)
+
+    def get_team_lead_ids(self, qa_concact_id: str) -> set[str]:
+        return self._get_role_ids(qa_concact_id, AllowedRoleTypes.team_lead.value)
+
+    def _get_role_ids(self, qa_concact_id: str, role: str) -> set[str]:
+        ids = set()
+        for t in self._teams:
+            people = t.group.resolved_people
+            for p in people:
+                if qa_concact_id == p.uid:
+                    roles = t.group.resolve_roles
+                    for e in roles.get_employees_for_role(role):
+                        ids.add(e.uid)
+        return ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ dependencies = [
     "openai >= 0.27.0",
     
     # Utilities
-    "glom >= 23.1.1"
+    "glom >= 23.1.1",
+
+    # Cyborg
+    "cyborg@git+ssh://git@github.com/openshift-eng/cyborg@master#subdirectory=org_tools/orglib",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This is just for future use.

Current issues:

1. **Private repository** - We would like to avoid using token or ssh for the Cyborg dependency
2. **Org_tools package is not a project** - setup.py or pyproject.toml is missing to be added as a dependency
3. **Relative imports** - Org_tools uses relative imports and ithe tool is added as dependency, modules cannot be found. (for example in main-py: `from container import Container` should be `from orglib.container import Container`)
4. **Conflicting dependencies** - Cyborg uses strict dependencies resolving and there are dependency conflicts 