### PR TITLE
define variable parent_assembly to None

### DIFF
--- a/oar/core/configstore.py
+++ b/oar/core/configstore.py
@@ -351,6 +351,9 @@ class ConfigStore:
         if "assembly" in basis:
             parent_assembly = self._get_value_by_path(
                 self._build_data["releases"], f"{basis['assembly']}/assembly")
+        else:
+            parent_assembly = None
+
         child_keypath = "%s!" % keypath
 
         attr_val = self._get_value_by_path(self._assembly, child_keypath)


### PR DESCRIPTION
In some cases, the `parent_assembly` variable is not defined which causes an exception like below.  Set the variable to a default.

```
  File "/Users/pruan/workspace/github_repos/release-tests/oar/core/configstore.py", line 359, in _get_assembly_attr
    if attr_val == None and parent_assembly:  # no key found, try to get it from parent assembly
                            ^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'parent_assembly' where it is not associated with a value cannot access local variable 'parent_assembly' where it is not associated with a value
```