### PR TITLE
addresses OCPERT-121

### DIFF
--- a/oar/core/notification.py
+++ b/oar/core/notification.py
@@ -9,10 +9,9 @@ from slack_sdk.errors import SlackApiError
 
 import oar.core.util as util
 from oar.core.configstore import ConfigStore
-from oar.core.exceptions import NotificationException
+from oar.core.exceptions import NotificationException, JiraUnauthorizedException
 from oar.core.jira import JiraManager
 from oar.core.worksheet import TestReport
-from oar.core.exceptions import JiraUnauthorizedException
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
fix issue https://issues.redhat.com/browse/OCPERT-121?filter=-2

```
pruan@mac ~/workspace/github_repos/release-tests $ oar -r 4.19.0-rc.5 update-bug-list
2025-06-06T22:13:46Z: INFO: task [Bug to be verified] status is changed to [In Progress]
2025-06-06T22:14:25Z: INFO: found existing bug OCPBUGS-36859 in report, checking...
2025-06-06T22:14:26Z: INFO: bug status of OCPBUGS-36859 is not changed
2025-06-06T22:14:26Z: INFO: found existing bug OCPBUGS-56619 in report, checking...
2025-06-06T22:14:29Z: INFO: bug status of OCPBUGS-56619 is not changed
2025-06-06T22:14:29Z: INFO: found existing bug OCPBUGS-54487 in report, checking...
2025-06-06T22:14:30Z: INFO: bug status of OCPBUGS-54487 is not changed
2025-06-06T22:14:31Z: INFO: found existing bug OCPBUGS-56185 in report, checking...
2025-06-06T22:14:33Z: INFO: bug status of OCPBUGS-56185 is not changed
2025-06-06T22:14:34Z: INFO: found existing bug OCPBUGS-56560 in report, checking...
2025-06-06T22:14:34Z: INFO: bug status of OCPBUGS-56560 is not changed
2025-06-06T22:14:35Z: INFO: found existing bug OCPBUGS-56886 in report, checking...
2025-06-06T22:14:37Z: INFO: bug status of OCPBUGS-56886 is not changed
2025-06-06T22:25:33Z: ERROR: Cannot get jira issue OCPBUGS-47459 due to permission issue
Traceback (most recent call last):
  File "/Users/pruan/workspace/github_repos/release-tests/oar/core/jira.py", line 54, in get_issue
    issue = self._svc.issue(key)
            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/client.py", line 1810, in issue
    issue.find(id, params=params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 263, in find
    self._find_by_url(url, params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 279, in _find_by_url
    self._load(url, params=params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 451, in _load
    r = self._session.get(url, headers=headers, params=params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 247, in request
    elif raise_on_error(response, **processed_kwargs):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 72, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 403 url: https://issues.redhat.com/rest/api/2/issue/OCPBUGS-47459
	text: You do not have the permission to see the specified issue.

	response headers = {...}
	response text = {"errorMessages":["You do not have the permission to see the specified issue."],"errors":{}}
2025-06-06T22:53:39Z: ERROR: Cannot get jira issue OCPBUGS-47459 due to permission issue
Traceback (most recent call last):
  File "/Users/pruan/workspace/github_repos/release-tests/oar/core/jira.py", line 54, in get_issue
    issue = self._svc.issue(key)
            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/client.py", line 1810, in issue
    issue.find(id, params=params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 263, in find
    self._find_by_url(url, params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 279, in _find_by_url
    self._load(url, params=params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 451, in _load
    r = self._session.get(url, headers=headers, params=params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 247, in request
    elif raise_on_error(response, **processed_kwargs):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 72, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 403 url: https://issues.redhat.com/rest/api/2/issue/OCPBUGS-47459
	text: You do not have the permission to see the specified issue.

	response headers = {...}
	response text = {"errorMessages":["You do not have the permission to see the specified issue."],"errors":{}}
2025-06-06T22:53:39Z: ERROR: jira token does not have permission to access security bugs OCPBUGS-47459, ignore and continue
2025-06-06T23:11:11Z: INFO: sent slack message to <#forum-openshift-qe>
2025-06-06T23:11:11Z: INFO: checking all bugs are verified
2025-06-06T23:11:12Z: INFO: result is: no
pruan@mac ~/workspace/github_repos/release-tests (contiue_notification●)$ >....
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 263, in find
    self._find_by_url(url, params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 279, in _find_by_url
    self._load(url, params=params)
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resources.py", line 451, in _load
    r = self._session.get(url, headers=headers, params=params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 247, in request
    elif raise_on_error(response, **processed_kwargs):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/pruan/.pyenv/versions/3.12.9/lib/python3.12/site-packages/jira/resilientsession.py", line 72, in raise_on_error
    raise JIRAError(
jira.exceptions.JIRAError: JiraError HTTP 403 url: https://issues.redhat.com/rest/api/2/issue/OCPBUGS-47459
        text: You do not have the permission to see the specified issue.

        response headers = {...}
        response text = {"errorMessages":["You do not have the permission to see the specified issue."],"errors":{}}
2025-06-06T22:53:39Z: ERROR: jira token does not have permission to access security bugs OCPBUGS-47459, ignore and continue
2025-06-06T23:11:11Z: INFO: sent slack message to <#forum-openshift-qe>
2025-06-06T23:11:11Z: INFO: checking all bugs are verified
2025-06-06T23:11:12Z: INFO: result is: no
```
The output was able to be sent to Slack
https://redhat-internal.slack.com/archives/CH76YSYSC/p1749276671338319
