### PR TITLE
Disable few upgrade jobs for 4.19 stable build. 

### DIFF
--- a/_releases/ocp-4.19-test-jobs-amd64.json
+++ b/_releases/ocp-4.19-test-jobs-amd64.json
@@ -28,11 +28,13 @@
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-stable-4.19-upgrade-from-stable-4.19-azure-ipi-fips-f999",
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-stable-4.19-upgrade-from-stable-4.19-gcp-ipi-f999",
-      "upgrade": true
+      "upgrade": true,
+      "disabled": true
     }
   ]
 }


### PR DESCRIPTION
because the first z-stream version is not available. will enable these jobs when 4.19.1 is available.