### PR TITLE
Enable upgrade jobs for 4.19

### DIFF
--- a/_releases/ocp-4.19-test-jobs-amd64.json
+++ b/_releases/ocp-4.19-test-jobs-amd64.json
@@ -28,13 +28,11 @@
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-stable-4.19-upgrade-from-stable-4.19-azure-ipi-fips-f999",
-      "upgrade": true,
-      "disabled": true
+      "upgrade": true
     },
     {
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.19-automated-release-stable-4.19-upgrade-from-stable-4.19-gcp-ipi-f999",
-      "upgrade": true,
-      "disabled": true
+      "upgrade": true
     }
   ]
 }


### PR DESCRIPTION
4.19.1 is available, enable the auto release jobs for upgrade testing b/w patch releases.