### PR TITLE
OCPERT-129 Enable 4.20 on test result dashboard

### DIFF
--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -120,7 +120,7 @@ cola, colb = st.columns(2, vertical_alignment='bottom')
 with cola:
     release = st.selectbox(
         'Choose minor release',
-        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19")
+        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20")
     )
 # clear cache manually if you want to get latest results
 with colb:


### PR DESCRIPTION
Enable auto release jobs for 4.20
JIRA: https://issues.redhat.com/browse/OCPERT-129