### PR TITLE
[OCPERT-128]Introduce a new flag for drop bugs command to drop the non-CVE issues forcibly

### DIFF
--- a/oar/cli/cmd_drop_bugs.py
+++ b/oar/cli/cmd_drop_bugs.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.pass_context
-@click.option("--force", is_flag=True, default=False,
-              help="Drop all unverified bugs expect CVEs.")
+@click.option("-f", "--force", is_flag=True, default=False,
+              help="Drop all unverified bugs except CVEs.")
 def drop_bugs(ctx, force):
     """
     Drop bugs from advisories

--- a/oar/cli/cmd_drop_bugs.py
+++ b/oar/cli/cmd_drop_bugs.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.pass_context
-def drop_bugs(ctx):
+@click.option("--force", is_flag=True, default=False,
+              help="Drop all unverified bugs expect CVEs.")
+def drop_bugs(ctx, force):
     """
     Drop bugs from advisories
     """
@@ -27,7 +29,7 @@ def drop_bugs(ctx):
         report.update_task_status(LABEL_TASK_DROP_BUGS, TASK_STATUS_INPROGRESS)
         # check doc and product security approval advisories
         approved_doc_ads, approved_prodsec_ads = am.get_doc_prodsec_approved_ads()
-        dropped_bugs, high_severity_bugs = am.drop_bugs()
+        dropped_bugs, high_severity_bugs = am.drop_bugs(force)
         # check if all bugs are verified
         nm = NotificationManager(cs)
         requested_doc_ads = []

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -196,7 +196,7 @@ class AdvisoryManager:
         If force is set, then drop all the not verified bug except CVEs.
 
         Args:
-            force (bool): If True, drop all the not verified bug except CVEs
+            force (bool): If True, drop all the not verified bug except CVEs.
 
         Raises:
             AdvisoryException: error when dropping bugs from advisory
@@ -213,7 +213,7 @@ class AdvisoryManager:
             if force:
                 high_severity_bugs, drop_bug_list = jm.get_unverified_issues_except_cve(issues)
             else:
-                high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
+                drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
             all_high_severity_bugs.extend(high_severity_bugs)
 
             if drop_bug_list:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -193,7 +193,7 @@ class AdvisoryManager:
     def drop_bugs(self, force):
         """
         Go through all attached bugs. Drop the not verified bugs if they're not critical/blocker/customer_case/CVE by default.
-        If force is set, then drop all the not verified bug except CVEs.
+        If force is set, then drop all the not verified bugs except CVEs.
 
         Args:
             force (bool): If True, drop all the not verified bug except CVEs.

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -211,9 +211,9 @@ class AdvisoryManager:
         for ad in ads:
             issues = ad.jira_issues
             if force:
-                high_severity_bugs, drop_bug_list = jm.get_unverified_issues_except_cve(issues)
+                drop_bug_list = jm.get_unverified_issues_except_cve(issues)
             else:
-                drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
+                high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
             all_high_severity_bugs.extend(high_severity_bugs)
 
             if drop_bug_list:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -192,8 +192,11 @@ class AdvisoryManager:
 
     def drop_bugs(self, force):
         """
-        Go through all attached bugs. Drop the not verified bugs if they're not critical/blocker/customer_case/CVE by defalut.
-        If force set, then drop all the not verified bug except CVEs.
+        Go through all attached bugs. Drop the not verified bugs if they're not critical/blocker/customer_case/CVE by default.
+        If force is set, then drop all the not verified bug except CVEs.
+
+        Args:
+            force (bool): If True, drop all the not verified bug except CVEs
 
         Raises:
             AdvisoryException: error when dropping bugs from advisory
@@ -207,7 +210,10 @@ class AdvisoryManager:
         all_high_severity_bugs = []
         for ad in ads:
             issues = ad.jira_issues
-            high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues,force)
+            if force:
+                high_severity_bugs, drop_bug_list = jm.get_unverified_issues_except_cve(issues)
+            else:
+                high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
             all_high_severity_bugs.extend(high_severity_bugs)
 
             if drop_bug_list:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -190,9 +190,10 @@ class AdvisoryManager:
         except Exception as e:
             raise AdvisoryException(f"change advisory status failed") from e
 
-    def drop_bugs(self):
+    def drop_bugs(self, force):
         """
-        Go through all attached bugs. Drop the not verified bugs if they're not critical/blocker/customer_case/CVE
+        Go through all attached bugs. Drop the not verified bugs if they're not critical/blocker/customer_case/CVE by defalut.
+        If force set, then drop all the not verified bug except CVEs.
 
         Raises:
             AdvisoryException: error when dropping bugs from advisory
@@ -206,7 +207,7 @@ class AdvisoryManager:
         all_high_severity_bugs = []
         for ad in ads:
             issues = ad.jira_issues
-            high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues)
+            high_severity_bugs, drop_bug_list = jm.get_high_severity_and_can_drop_issues(issues,force)
             all_high_severity_bugs.extend(high_severity_bugs)
 
             if drop_bug_list:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -196,7 +196,7 @@ class AdvisoryManager:
         If force is set, then drop all the not verified bugs except CVEs.
 
         Args:
-            force (bool): If True, drop all the not verified bug except CVEs.
+            force (bool): If True, drop all the not verified bugs except CVEs.
 
         Raises:
             AdvisoryException: error when dropping bugs from advisory

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -240,7 +240,7 @@ class JiraManager:
     
     def get_unverified_issues_except_cve(self, jira_issue_keys):
         """
-        Get list of CVE issues and list of the other issues that can be dropped by force after confirm droppable message sending.
+        Get list of all the other issues except CVEs that can be dropped by force after confirm droppable message sending.
 
         Args:
             jira_issue_keys (list[str]): jira issues keys to be processed

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -213,7 +213,7 @@ class JiraManager:
             raise JiraException(
                 "invalid input argument key or comment is empty")
 
-    def get_high_severity_and_can_drop_issues(self, jira_issue_keys):
+    def get_high_severity_and_can_drop_issues(self, jira_issue_keys, force):
         """
         Get list of critical, blocker, customer or CVE issues and list of issues that can be dropped without confirming
 
@@ -232,7 +232,13 @@ class JiraManager:
                     continue
                 else:
                     if issue.is_high_severity_issue():
-                        high_severity_issues.append(key)
+                        if force:
+                            if issue.is_cve_tracker():
+                                high_severity_issues.append(key)
+                            else:
+                                can_drop_issues.append(key)
+                        else:
+                            high_severity_issues.append(key)
                     else:
                         can_drop_issues.append(key)
 

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -256,7 +256,7 @@ class JiraManager:
                     continue
                 else:
                     if issue.is_cve_tracker():
-                        logger.warning(f"jira issue {issue.get_key()} is cve tracker: {issue.is_cve_tracker()}, it must be verified")
+                        logger.warning(f"jira issue {issue.get_key()} is cve tracker, it cannot be dropped")
                     else:
                         can_drop_issues.append(key)
 

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -246,9 +246,8 @@ class JiraManager:
             jira_issue_keys (list[str]): jira issues keys to be processed
 
         Returns:
-            tuple[list[str], list[str]]: list of CVE jira keys that are still to be verified, list of jira keys that can be dropped by force.
+            tuple[list[str]]: list of jira keys that can be dropped by force.
         """
-        cve_issues = []
         can_drop_issues = []
         if jira_issue_keys:
             for key in jira_issue_keys:
@@ -258,11 +257,10 @@ class JiraManager:
                 else:
                     if issue.is_cve_tracker():
                         logger.warning(f"jira issue {issue.get_key()} is cve tracker: {issue.is_cve_tracker()}, it must be verified")
-                        cve_issues.append(key)
                     else:
                         can_drop_issues.append(key)
 
-        return cve_issues, can_drop_issues
+        return can_drop_issues
 
     def get_unverified_cve_issues(self, jira_issue_keys: list[str]):
         """

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -107,7 +107,7 @@ class TestJiraManager(unittest.TestCase):
         self.assertRaises(JiraException, self.jm.add_comment, "", "")
         self.assertRaises(JiraException, self.jm.add_comment, None, None)
 
-    def test_get_high_severity_and_can_drop_issues(self):
+    def test_get_high_severity_or_cve_and_can_drop_issues(self):
         # Prepare test data
         # Fields indicating CVE, release blocker and customer case issue at the same time
         fields_full = {
@@ -204,9 +204,7 @@ class TestJiraManager(unittest.TestCase):
         mock_jira = Mock(spec=JIRA)
         mock_jira.issue.side_effect = lambda key: mock_issues.get(key, None)
         self.jm._svc = mock_jira
-
-        # Call the tested method with force=False
-        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data, force=False)
+        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data)
 
         # Assertions
         for key in high_severity_issues_data:
@@ -218,9 +216,7 @@ class TestJiraManager(unittest.TestCase):
         for key in closed_issues_data:
             self.assertNotIn(key, high_severity_issues)
             self.assertNotIn(key, can_drop_issues)
-
-        # Call the tested method with force=True
-        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data, force=True)
+        high_severity_issues, can_drop_issues = self.jm.get_unverified_issues_except_cve(all_issues_data)
 
         # Assertions
         for key in cve_data:

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -219,7 +219,7 @@ class TestJiraManager(unittest.TestCase):
             self.assertNotIn(key, high_severity_issues)
             self.assertNotIn(key, can_drop_issues)
 
-        # Call the tested method with force=False
+        # Call the tested method with force=True
         high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data, force=True)
 
         # Assertions

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -160,16 +160,12 @@ class TestJiraManager(unittest.TestCase):
         high_severity_issues_data = {
             "OCPBUGS-n100": {"status": "ON_QA", "priority": "Blocker"},
             "OCPBUGS-n101": {"status": "ON_QA", "priority": "Critical"},
-            "OCPBUGS-n102": {"status": "ON_QA", "priority": "Major", "fields": fields_full},
-            "OCPBUGS-n103": {"status": "ON_QA", "priority": "Normal", "fields": fields_CVE_1},
-            "OCPBUGS-n104": {"status": "ON_QA", "priority": "Minor", "fields": fields_CVE_2},
             "OCPBUGS-n105": {"status": "ON_QA", "priority": "Major", "fields": fields_blocker_1},
             "OCPBUGS-n106": {"status": "ON_QA", "priority": "Major", "fields": fields_blocker_2},
             "OCPBUGS-n107": {"status": "ON_QA", "priority": "Undefined", "fields": fields_blocker_3},
             "OCPBUGS-n108": {"status": "ON_QA", "priority": "Major", "fields": fields_customer_case},
             "OCPBUGS-n109": {"status": "ON_QA", "priority": "Blocker", "fields": fields_low_severity},
-            "OCPBUGS-n110": {"status": "New", "priority": "Blocker"},
-            "OCPBUGS-n111": {"status": "Assigned", "priority": "Critical", "fields": fields_full},
+            "OCPBUGS-n110": {"status": "New", "priority": "Blocker"}
         }
 
         can_drop_issues_data = {
@@ -191,7 +187,14 @@ class TestJiraManager(unittest.TestCase):
             "OCPBUGS-n183": {"status": "Verified", "priority": "Normal"}
         }
 
-        all_issues_data = ChainMap(high_severity_issues_data, can_drop_issues_data, closed_issues_data)
+        cve_data = {
+            "OCPBUGS-n102": {"status": "ON_QA", "priority": "Major", "fields": fields_full},
+            "OCPBUGS-n103": {"status": "ON_QA", "priority": "Normal", "fields": fields_CVE_1},
+            "OCPBUGS-n104": {"status": "ON_QA", "priority": "Minor", "fields": fields_CVE_2},
+            "OCPBUGS-n111": {"status": "Assigned", "priority": "Critical", "fields": fields_full},
+        }
+
+        all_issues_data = ChainMap(high_severity_issues_data, can_drop_issues_data, closed_issues_data, cve_data)
 
         # Prepare mocks
         mock_issues = {}
@@ -202,12 +205,28 @@ class TestJiraManager(unittest.TestCase):
         mock_jira.issue.side_effect = lambda key: mock_issues.get(key, None)
         self.jm._svc = mock_jira
 
-        # Call the tested method
-        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data)
+        # Call the tested method with force=False
+        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data, force=False)
 
         # Assertions
         for key in high_severity_issues_data:
             self.assertIn(key, high_severity_issues)
+        for key in cve_data:
+            self.assertIn(key, high_severity_issues)
+        for key in can_drop_issues_data:
+            self.assertIn(key, can_drop_issues)
+        for key in closed_issues_data:
+            self.assertNotIn(key, high_severity_issues)
+            self.assertNotIn(key, can_drop_issues)
+
+        # Call the tested method with force=False
+        high_severity_issues, can_drop_issues = self.jm.get_high_severity_and_can_drop_issues(all_issues_data, force=True)
+
+        # Assertions
+        for key in cve_data:
+            self.assertIn(key, high_severity_issues)
+        for key in high_severity_issues_data:
+            self.assertIn(key, can_drop_issues)
         for key in can_drop_issues_data:
             self.assertIn(key, can_drop_issues)
         for key in closed_issues_data:

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -216,6 +216,7 @@ class TestJiraManager(unittest.TestCase):
         for key in closed_issues_data:
             self.assertNotIn(key, high_severity_issues)
             self.assertNotIn(key, can_drop_issues)
+
         can_drop_issues = self.jm.get_unverified_issues_except_cve(all_issues_data)
 
         # Assertions

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -107,7 +107,7 @@ class TestJiraManager(unittest.TestCase):
         self.assertRaises(JiraException, self.jm.add_comment, "", "")
         self.assertRaises(JiraException, self.jm.add_comment, None, None)
 
-    def test_get_high_severity_or_cve_and_can_drop_issues(self):
+    def test_get_high_severity_and_can_drop_issues(self):
         # Prepare test data
         # Fields indicating CVE, release blocker and customer case issue at the same time
         fields_full = {
@@ -216,11 +216,11 @@ class TestJiraManager(unittest.TestCase):
         for key in closed_issues_data:
             self.assertNotIn(key, high_severity_issues)
             self.assertNotIn(key, can_drop_issues)
-        high_severity_issues, can_drop_issues = self.jm.get_unverified_issues_except_cve(all_issues_data)
+        can_drop_issues = self.jm.get_unverified_issues_except_cve(all_issues_data)
 
         # Assertions
         for key in cve_data:
-            self.assertIn(key, high_severity_issues)
+            self.assertNotIn(key, can_drop_issues)
         for key in high_severity_issues_data:
             self.assertIn(key, can_drop_issues)
         for key in can_drop_issues_data:


### PR DESCRIPTION
python -m unittest tests.test_jira.TestJiraManager.test_get_high_severity_and_can_drop_issues
jira issue OCPBUGS-n102 is cve tracker: True, it must be verified
jira issue OCPBUGS-n103 is cve tracker: True, it must be verified
jira issue OCPBUGS-n104 is cve tracker: True, it must be verified
jira issue OCPBUGS-n111 is cve tracker: True, it must be verified
jira issue OCPBUGS-n100 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n101 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n105 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n106 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n107 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n108 is critical: False or customer case: True, it should be verified
jira issue OCPBUGS-n109 is critical: True or customer case: , it should be verified
jira issue OCPBUGS-n110 is critical: True or customer case: None, it should be verified
jira issue OCPBUGS-n102 is cve tracker, it cannot be dropped
jira issue OCPBUGS-n103 is cve tracker, it cannot be dropped
jira issue OCPBUGS-n104 is cve tracker, it cannot be dropped
jira issue OCPBUGS-n111 is cve tracker, it cannot be dropped

Ran 1 test in 49.506s

OK

