### PR TITLE
OCPERT-134 Make OAR v2 compatible with both errata advisory and shipment data

### DIFF
--- a/oar/cli/cmd_drop_bugs.py
+++ b/oar/cli/cmd_drop_bugs.py
@@ -2,10 +2,9 @@ import logging
 
 import click
 
-from oar.core.advisory import AdvisoryManager
 from oar.core.const import *
 from oar.core.notification import NotificationManager
-from oar.core.shipment import ShipmentData
+from oar.core.operators import BugOperator
 from oar.core.worksheet import WorksheetManager
 
 logger = logging.getLogger(__name__)
@@ -16,30 +15,31 @@ logger = logging.getLogger(__name__)
 def drop_bugs(ctx):
     """
     Drop bugs from advisories
+
+    If new pre-merge verification method is active, we only pick up verified bugs to shipment resource
+    QE leads don't have to drop bugs
     """
     # get config store from context
     cs = ctx.obj["cs"]
     try:
         # get existing report
         report = WorksheetManager(cs).get_test_report()
-        # init advisory manager
-        am = AdvisoryManager(cs)
-        # init shipment data
-        sd = ShipmentData(cs)
+        # init bug operator
+        operator = BugOperator(cs)
         # update task status to in progress
         report.update_task_status(LABEL_TASK_DROP_BUGS, TASK_STATUS_INPROGRESS)
         # check doc and product security approval advisories
-        # TODO: need to confirm how to collabrate with doc and prodsec team 
-        approved_doc_ads, approved_prodsec_ads = am.get_doc_prodsec_approved_ads()
-        dropped_bugs, high_severity_bugs = sd.drop_bugs()
+        # TODO: need to confirm how to collabrate with doc and prodsec team
+        approved_doc_ads, approved_prodsec_ads = operator._am.get_doc_prodsec_approved_ads()
+        dropped_bugs, high_severity_bugs = operator.drop_bugs()
         # check if all bugs are verified
         nm = NotificationManager(cs)
         requested_doc_ads = []
         requested_prodsec_ads = []
         if len(dropped_bugs) or len(high_severity_bugs):
             logger.info("updating test report")
-            report.update_bug_list(am.get_jira_issues())
-            NotificationManager(cs).share_dropped_and_high_severity_bugs(
+            report.update_bug_list(operator._am.get_jira_issues())
+            nm.share_dropped_and_high_severity_bugs(
                 dropped_bugs, high_severity_bugs
             )
             if len(approved_doc_ads):

--- a/oar/cli/cmd_update_bug_list.py
+++ b/oar/cli/cmd_update_bug_list.py
@@ -5,8 +5,8 @@ import click
 from oar.core.const import *
 from oar.core.jira import JiraManager
 from oar.core.notification import NotificationManager
+from oar.core.operators import BugOperator
 from oar.core.worksheet import WorksheetManager
-from oar.core.shipment import ShipmentData
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +32,9 @@ def update_bug_list(ctx, notify, confirm_droppable, notify_managers):
         report = WorksheetManager(cs).get_test_report()
         # update task status to in progress
         report.update_task_status(LABEL_TASK_BUGS_TO_VERIFY, TASK_STATUS_INPROGRESS)
-        # refresh bug list
-        jira_issues = ShipmentData(cs).get_jira_issues()
+        # refresh bug list using operator
+        operator = BugOperator(cs)
+        jira_issues = operator.get_jira_issues()
         report.update_bug_list(jira_issues)
         # send notification
         if notify:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -36,15 +36,12 @@ class AdvisoryManager:
         """
         ads = []
         for k, v in self._cs.get_advisories().items():
-            if k == AD_IMPETUS_MICROSHIFT:
-                continue
-            ad = Advisory(
-                errata_id=v,
-                impetus=k,
-            )
-            if ad.errata_state != AD_STATUS_DROPPED_NO_SHIP:
-                ads.append(ad)
-
+            # in new release flow, we only need to handle rpm advisory
+            # because rpm build is not supported by konflux
+            if k == AD_IMPETUS_RPM:
+                ad = Advisory(errata_id=v, impetus=k)
+                if ad.errata_state != AD_STATUS_DROPPED_NO_SHIP:
+                    ads.append(ad)
         return ads
 
     def get_jira_issues(self):

--- a/oar/core/configstore.py
+++ b/oar/core/configstore.py
@@ -80,6 +80,16 @@ class ConfigStore:
 
         return self._get_assembly_attr("group/advisories")
 
+    def get_rpm_advisory(self):
+        """
+        Get RPM advisory ID from build data if exists
+        
+        Returns:
+            str: RPM advisory ID or None if not found
+        """
+        advisories = self.get_advisories()
+        return advisories.get(AD_IMPETUS_RPM) if advisories else None
+
     def get_candidate_builds(self):
         """
         Get candidate nightly builds from build data e.g.

--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -1,0 +1,58 @@
+from oar.core.advisory import AdvisoryManager
+from oar.core.shipment import ShipmentData
+from oar.core.jira import JiraManager
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ReleaseOwnershipOperator:
+    """Handles composite ownership operations across advisories and shipments"""
+    
+    def __init__(self, cs):
+        self._am = AdvisoryManager(cs)
+        self._sd = ShipmentData(cs)
+
+    def update_owners(self, email: str) -> tuple[list, list]:
+        """Update ownership across advisories and shipments"""
+        try:
+            updated_ads, abnormal_ads = self._am.change_ad_owners()
+            self._sd.add_qe_release_lead_comment(email)
+            return updated_ads, abnormal_ads
+        except Exception as e:
+            logger.error(f"Ownership operation failed: {str(e)}")
+            raise
+
+class BugOperator:
+    """Handles composite bug operations across advisories and shipments"""
+    
+    def __init__(self, cs):
+        self._am = AdvisoryManager(cs)
+        self._sd = ShipmentData(cs)
+        self._jm = JiraManager(cs)
+
+    def get_jira_issues(self) -> list:
+        """Get jira issues from both advisory and shipment sources"""
+        try:
+            advisory_issues = self._am.get_jira_issues()
+            shipment_issues = self._sd.get_jira_issues()
+            return sorted(set(advisory_issues + shipment_issues))
+        except Exception as e:
+            logger.error(f"Bug sync failed: {str(e)}")
+            raise
+
+    def drop_bugs(self) -> tuple[list, list]:
+        """Execute bug drop operation across both sources"""
+        try:
+            # Drop from advisories first
+            dropped_from_ads, high_severity = self._am.drop_bugs()
+            
+            # Then drop from shipments
+            high_from_shipments, dropped_from_shipments = self._sd.drop_bugs()
+            
+            return (
+                dropped_from_ads + dropped_from_shipments,
+                high_severity + high_from_shipments
+            )
+        except Exception as e:
+            logger.error(f"Bug drop failed: {str(e)}")
+            raise

--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -1,6 +1,7 @@
 from oar.core.advisory import AdvisoryManager
 from oar.core.shipment import ShipmentData
 from oar.core.jira import JiraManager
+from oar.core.configstore import ConfigStore
 import logging
 
 logger = logging.getLogger(__name__)
@@ -8,12 +9,16 @@ logger = logging.getLogger(__name__)
 class ReleaseOwnershipOperator:
     """Handles composite ownership operations across advisories and shipments"""
     
-    def __init__(self, cs):
+    def __init__(self, cs: ConfigStore):
         self._am = AdvisoryManager(cs)
         self._sd = ShipmentData(cs)
 
     def update_owners(self, email: str) -> tuple[list, list]:
-        """Update ownership across advisories and shipments"""
+        """Update ownership across advisories and shipments
+        
+        Returns:
+            tuple[list, list]: (list of updated advisories, list of advisories with abnormal states)
+        """
         try:
             updated_ads, abnormal_ads = self._am.change_ad_owners()
             self._sd.add_qe_release_lead_comment(email)
@@ -25,7 +30,7 @@ class ReleaseOwnershipOperator:
 class BugOperator:
     """Handles composite bug operations across advisories and shipments"""
     
-    def __init__(self, cs):
+    def __init__(self, cs: ConfigStore):
         self._am = AdvisoryManager(cs)
         self._sd = ShipmentData(cs)
         self._jm = JiraManager(cs)
@@ -41,7 +46,11 @@ class BugOperator:
             raise
 
     def drop_bugs(self) -> tuple[list, list]:
-        """Execute bug drop operation across both sources"""
+        """Execute bug drop operation across both sources
+        
+        Returns:
+            tuple[list, list]: (list of successfully dropped bugs, list of high severity bugs that couldn't be dropped)
+        """
         try:
             # Drop from advisories first
             dropped_from_ads, high_severity = self._am.drop_bugs()

--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -611,7 +611,7 @@ class TestReport:
         
         Args:
             cell_label (str): The cell label to update (e.g. "A1")
-            links_data (list): List of tuples containing (link, display_text)
+            links_data (list): List of tuples containing (display_text, link)
         """
         try:
             # Try advanced formatting first

--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -155,17 +155,17 @@ class TestReport:
         """
         return self._ws.url
 
-    def update_shipment_info(self, shipment_mrs, rpm_advisory_id):
+    def update_shipment_info(self, shipment_mrs, rpm_advisory):
         """
         Update shipment info in test report with shipment MRs and RPM advisory link
 
         Args:
             shipment_mrs (list): List of shipment MR URLs
-            rpm_advisory_link (str): RPM advisory link
+            rpm_advisory (str): RPM advisory ID (will be converted to full link)
         """
         links_data = []
-        if rpm_advisory_id:
-            links_data.append((f"rpm: {rpm_advisory_id} ", util.get_advisory_link(rpm_advisory_id)))
+        if rpm_advisory:
+            links_data.append((f"rpm: {rpm_advisory} ", util.get_advisory_link(rpm_advisory)))
 
         for mr in shipment_mrs:
             links_data.append((mr, mr))

--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -91,11 +91,12 @@ class WorksheetManager:
             logger.info("build info is updated")
             logger.debug(f"build info:\n{build_cell_value}")
 
-            # update shipment MRs
-            shipment_cell_value = "\n".join(self._cs.get_shipment_mrs())
-            self._report.update_shipment_info(shipment_cell_value)
+            # update shipment MRs and RPM advisory link
+            shipment_mrs = self._cs.get_shipment_mrs()
+            rpm_advisory = self._cs.get_rpm_advisory()
+            self._report.update_shipment_info(shipment_mrs, rpm_advisory)
             logger.info("shipment info is updated")
-            logger.debug(f"shipment info:\n{shipment_cell_value}")
+            logger.debug(f"shipment info:\n MR: {shipment_mrs}\nRPM advisory id: {rpm_advisory}")
 
             # update jira info
             self._report.update_jira_info(self._cs.get_jira_ticket())
@@ -154,14 +155,22 @@ class TestReport:
         """
         return self._ws.url
 
-    def update_shipment_info(self, shipment):
+    def update_shipment_info(self, shipment_mrs, rpm_advisory_id):
         """
-        Update shipment info in test report
+        Update shipment info in test report with shipment MRs and RPM advisory link
 
         Args:
-            shipment (str): shipment info of current release
+            shipment_mrs (list): List of shipment MR URLs
+            rpm_advisory_link (str): RPM advisory link
         """
-        self._ws.update_acell(LABEL_SHIPMENT, self._to_hyperlink(shipment, shipment))
+        links_data = []
+        if rpm_advisory_id:
+            links_data.append((f"rpm: {rpm_advisory_id} ", util.get_advisory_link(rpm_advisory_id)))
+
+        for mr in shipment_mrs:
+            links_data.append((mr, mr))
+        
+        self.update_cell_with_hyperlinks(LABEL_SHIPMENT, links_data)
 
     def get_shipment_info(self):
         """
@@ -595,3 +604,51 @@ class TestReport:
 
     def _to_hyperlink(self, link, label):
         return f'=HYPERLINK("{link}","{label}")'
+
+    def update_cell_with_hyperlinks(self, cell_label, links_data):
+        """
+        Update a cell with multiple hyperlinks, each on a new line
+        
+        Args:
+            cell_label (str): The cell label to update (e.g. "A1")
+            links_data (list): List of tuples containing (link, display_text)
+        """
+        try:
+            # Try advanced formatting first
+            text = "\n".join([text for text, link in links_data])
+            text_format_runs = []
+            for txt, link in links_data:
+                text_format_runs.append({
+                    "startIndex": text.find(txt),
+                    "format": {"link": {"uri": link}}
+                })
+
+            # Convert cell label to row and column indices
+            row, col = gspread.utils.a1_to_rowcol(cell_label)
+            
+            requests = [{
+                "updateCells": {
+                    "rows": [{
+                        "values": [{
+                            "userEnteredValue": {"stringValue": text},
+                            "textFormatRuns": text_format_runs
+                        }]
+                    }],
+                    "range": {
+                        "sheetId": self._ws.id,
+                        "startRowIndex": row - 1,
+                        "endRowIndex": row,
+                        "startColumnIndex": col - 1,
+                        "endColumnIndex": col
+                    },
+                    "fields": "userEnteredValue,textFormatRuns"
+                }
+            }]
+            self._ws.spreadsheet.batch_update({"requests": requests})
+        except Exception as e:
+            logger.warning(f"Advanced hyperlink formatting failed, falling back to simple HYPERLINK: {e}")
+            # Fall back to simple HYPERLINK formulas
+            hyperlinks = []
+            for text, link in links_data:
+                hyperlinks.append(self._to_hyperlink(link, text))
+            self._ws.update_acell(cell_label, "\n".join(hyperlinks))

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -5,6 +5,7 @@ from oar.core.configstore import ConfigStore
 from oar.core.const import *
 from oar.core.exceptions import WorksheetException
 from oar.core.worksheet import WorksheetManager
+from oar.core.worksheet import TestReport
 
 
 class TestWorksheetManager(TestCase):
@@ -116,3 +117,19 @@ class TestWorksheetManager(TestCase):
             "https://qe-component-readiness.dptools.openshift.org/sippy-ng/component_readiness/main?view=4.15-qe-auto-release",
             tr._ws.get(LABEL_SIPPY_AUTO_RELEASE, value_render_option="FORMULA")[0][0],
         ) 
+
+    def test_update_cell_with_hyperlinks(self):
+
+        # test data
+        mr_url = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/31"
+        rpm_advisory = "149403"
+        
+        # hack the test report with specified worksheet
+        cs = ConfigStore("4.19.2")
+        ws = WorksheetManager(cs)._doc.worksheet("template-for-konflux")
+        tr = TestReport(ws, cs)
+        tr.update_shipment_info([mr_url], rpm_advisory)
+        # verify the cell content
+        info = tr.get_shipment_info()
+        self.assertIn(mr_url, info)
+        self.assertIn(f"rpm: {rpm_advisory}", info)


### PR DESCRIPTION
Refactor core operations into operator classes, to make OAR v2 compatible with both AD and shipment data

- Introduce BugOperator and ReleaseOwnershipOperator to consolidate related operations
- Move bug dropping and ownership management logic into respective operator classes
- Update CLI commands to use new operator classes instead of direct ShipmentData usage
- Improve documentation for drop_bugs command regarding pre-merge verification
- Add handling for abnormal advisories in ownership updates
- Include new operators.py file for operator implementations

The changes centralize related operations into dedicated classes for better organization and maintainability while preserving existing functionality.