### PR TITLE
OCPERT-133 Enhance worksheet link formatting with advanced options

### DIFF
--- a/oar/core/worksheet.py
+++ b/oar/core/worksheet.py
@@ -657,7 +657,7 @@ class TestReport:
             raise WorksheetException("links_data cannot be empty")
         try:
             # Try advanced formatting first
-            text = "\n".join([text for text, link, *_ in links_data])
+            text = "\n".join([item[0] for item in links_data])  # Extract just the display text
             text_format_runs = []
             for item in links_data:
                 display_text = item[0]
@@ -726,11 +726,11 @@ class TestReport:
             }]
             self._ws.spreadsheet.batch_update({"requests": requests})
         except Exception as e:
-            logger.warning(f"Advanced hyperlink formatting failed, falling back to simple HYPERLINK: {e}")
-            # Fall back to simple HYPERLINK formulas
-            hyperlinks = []
+            logger.warning(f"Advanced hyperlink formatting failed, falling back to plain text with URLs: {e}")
+            # Fall back to plain text with URLs
+            plain_text = []
             for item in links_data:
                 display_text = item[0]
                 link = item[1]
-                hyperlinks.append(self._to_hyperlink(link, display_text))
-            self._ws.update_acell(cell_label, "\n".join(hyperlinks))
+                plain_text.append(f"{display_text} ({link})")
+            self._ws.update_acell(cell_label, "\n".join(plain_text))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     
     # External service integrations
     "gspread == 5.10.0",
-    "gspread-formatting >= 1.1.2",
+    "gspread-formatting >= 1.2.1",
     "errata-tool >= 1.29.0",
     "slack_sdk >= 3.21.3",
     "requests-gssapi ~= 1.2.3",

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -247,7 +247,7 @@ class TestTestReport(TestCase):
             self.tr.update_cell_with_hyperlinks("D4", [])
 
     def test_hyperlink_fallback_solution(self):
-        """Test fallback to simple HYPERLINK when advanced formatting fails"""
+        """Test fallback to plain text when advanced formatting fails"""
         # Setup test data
         links_data = [
             ("Test link", "https://example.com"),
@@ -265,13 +265,15 @@ class TestTestReport(TestCase):
             self.tr.update_cell_with_hyperlinks("E5", links_data)
             
             # Verify warning was logged about fallback
-            self.assertIn("Advanced hyperlink formatting failed, falling back to simple HYPERLINK", cm.output[0])
+            self.assertIn("Advanced hyperlink formatting failed, falling back to plain text with URLs", cm.output[0])
         
         # Restore original method
         self.ws.spreadsheet.batch_update = original_batch_update
         
-        # Verify fallback worked - cell should contain simple HYPERLINK formulas
-        cell_value = self.ws.acell("E5", value_render_option="FORMULA").value
+        # Verify fallback worked - cell should contain plain text with URLs
+        cell_value = self.ws.acell("E5").value
         for text, link in links_data:
-            expected_hyperlink = f'=HYPERLINK("{link}","{text}")'
-            self.assertIn(expected_hyperlink, cell_value)
+            expected_text = f"{text} ({link})"
+            self.assertIn(expected_text, cell_value)
+            # Verify no HYPERLINK formulas are present
+            self.assertNotIn('=HYPERLINK(', cell_value)

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 from gspread_formatting import get_text_format_runs
 import time
-import json
 
 from oar.core.advisory import AdvisoryManager
 from oar.core.configstore import ConfigStore


### PR DESCRIPTION
- Add support for partial text hyperlinks via linkable_text parameter
- Implement custom format runs for precise text styling
- Add comprehensive input validation and error handling
- Improve docstring with detailed examples and parameter explanations
- Fix RPM advisory link format in TestReport class
- Update version of gspread-formatting in pyproject.toml

The changes allow more flexible hyperlink formatting in worksheets, including:
- Linking only portions of display text
- Custom text formatting with format runs
- Better error handling for invalid inputs