### PR TITLE
OCPERT-98 Add jira notificator

### DIFF
--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -1,17 +1,23 @@
+from datetime import datetime, timedelta, timezone
 import os
 import unittest
 
 from unittest.mock import Mock
 
-from tools.jira_notificator import *
+from jira import JIRA
+
+from tools.jira_notificator import Contact, Notification, NotificationService, NotificationType
 
 class TestJiraNotificator(unittest.TestCase):
 
     def setUp(self):
         jira_token = os.environ.get("JIRA_TOKEN")
-        self.jira = JIRA(server="https://issues.redhat.com", token_auth=jira_token)
-        self.test_issue = self.jira.issue("OCPBUGS-59288", expand="changelog")
-        self.test_issues_without_qa = self.jira.issue("OCPBUGS-8760", expand="changelog")
+        jira = JIRA(server="https://issues.redhat.com", token_auth=jira_token)
+        self.ns = NotificationService(jira, True)
+
+        self.test_issue = jira.issue("OCPBUGS-59288", expand="changelog")
+        self.test_issue_without_qa = jira.issue("OCPBUGS-8760", expand="changelog")
+        self.test_issue_without_assignee = jira.issue("OCPBUGS-1542", expand="changelog")
 
         self.test_user = Mock()
         self.test_user.name = "tdavid"
@@ -20,28 +26,28 @@ class TestJiraNotificator(unittest.TestCase):
 
     def test_create_notification_title(self):
         self.assertEqual(
-            create_notification_title(NotificationType.QA_CONTACT),
+            self.ns.create_notification_title(NotificationType.QA_CONTACT),
             (
                 "Errata Reliability Team Notification - QA Contact Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
             )
         )
         self.assertEqual(
-            create_notification_title(NotificationType.TEAM_LEAD),
+            self.ns.create_notification_title(NotificationType.TEAM_LEAD),
             (
                 "Errata Reliability Team Notification - Team Lead Action Request\n"
                 "This issue has been in the ON_QA state for over 48 hours.\n"
             )
         )
         self.assertEqual(
-            create_notification_title(NotificationType.MANAGER),
+            self.ns.create_notification_title(NotificationType.MANAGER),
             (
                 "Errata Reliability Team Notification - Manager Action Request\n"
                 "This issue has been in the ON_QA state for over 72 hours.\n"
             )
         )
         self.assertEqual(
-            create_notification_title(NotificationType.ASSIGNEE),
+            self.ns.create_notification_title(NotificationType.ASSIGNEE),
             (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
@@ -49,58 +55,60 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
     def test_get_notification_type(self):
-        self.assertEqual(get_notification_type("QA Contact Action Request"), NotificationType.QA_CONTACT)
-        self.assertEqual(get_notification_type("Team Lead Action Request"), NotificationType.TEAM_LEAD)
-        self.assertEqual(get_notification_type("Manager Action Request"), NotificationType.MANAGER)
-        self.assertEqual(get_notification_type("Assignee Action Request"), NotificationType.ASSIGNEE)
-        self.assertEqual(get_notification_type("Please verify the issues as soon as possible."), None)
-        self.assertEqual(get_notification_type("QA Contact Manager Team Lead"), None)
-        self.assertEqual(get_notification_type(""), None)
+        self.assertEqual(self.ns.get_notification_type("QA Contact Action Request"), NotificationType.QA_CONTACT)
+        self.assertEqual(self.ns.get_notification_type("Team Lead Action Request"), NotificationType.TEAM_LEAD)
+        self.assertEqual(self.ns.get_notification_type("Manager Action Request"), NotificationType.MANAGER)
+        self.assertEqual(self.ns.get_notification_type("Assignee Action Request"), NotificationType.ASSIGNEE)
+        self.assertEqual(self.ns.get_notification_type("Please verify the issues as soon as possible."), None)
+        self.assertEqual(self.ns.get_notification_type("QA Contact Manager Team Lead"), None)
+        self.assertEqual(self.ns.get_notification_type(""), None)
 
     def test_create_jira_comment_mentions(self):
         second_user = Mock()
         second_user.name = "gjospin"
 
-        self.assertEqual(create_jira_comment_mentions([]), "")
-        self.assertEqual(create_jira_comment_mentions([self.test_user]), "[~tdavid] ")
-        self.assertEqual(create_jira_comment_mentions([self.test_user, second_user]), "[~tdavid] [~gjospin] ")
-
+        self.assertEqual(self.ns.create_jira_comment_mentions([]), "")
+        self.assertEqual(self.ns.create_jira_comment_mentions([self.test_user]), "[~tdavid] ")
+        self.assertEqual(self.ns.create_jira_comment_mentions([self.test_user, second_user]), "[~tdavid] [~gjospin] ")
+    
     def test_process_notification(self):
         jira_mock = Mock()
         notification = Notification(self.test_issue, NotificationType.QA_CONTACT, "Hello")
 
-        process_notification(jira_mock, notification, True)
+        ns_dry = NotificationService(jira_mock, True)
+        ns_dry.process_notification(notification)
         jira_mock.add_comment.assert_not_called()
 
-        process_notification(jira_mock, notification, False)
+        ns_live = NotificationService(jira_mock, False)
+        ns_live.process_notification(notification)
         jira_mock.add_comment.assert_called_once_with(notification.issue, notification.text)
-
+    
     def test_find_user_by_email(self):
-        self.assertEqual(find_user_by_email(self.jira, "tdavid@redhat.com").displayName, "Tomas David")
-        self.assertEqual(find_user_by_email(self.jira, "dtomas@redhat.com"), None)
+        self.assertEqual(self.ns.find_user_by_email("tdavid@redhat.com").displayName, "Tomas David")
+        self.assertEqual(self.ns.find_user_by_email("dtomas@redhat.com"), None)
 
     def test_get_qa_contact(self):
-        qa_contact = get_qa_contact(self.test_issue)
+        qa_contact = self.ns.get_qa_contact(self.test_issue)
         self.assertEqual(qa_contact.displayName, "Tomas David")
         self.assertEqual(qa_contact.name, "tdavid@redhat.com")
 
-        self.assertEqual(get_qa_contact(self.test_issues_without_qa), None)
+        self.assertEqual(self.ns.get_qa_contact(self.test_issue_without_qa), None)
     
     def test_get_manager(self):
-        manager = get_manager(self.jira, self.test_user)
+        manager = self.ns.get_manager(self.test_user)
         self.assertEqual(manager.displayName, "Gui Jospin")
         self.assertEqual(manager.name, "rhn-support-gjospin")
 
         nont_existing_user = Mock()
         nont_existing_user.emailAddress = "dtomas@redhat.com"
-        self.assertEqual(get_manager(self.jira, nont_existing_user), None)
+        self.assertEqual(self.ns.get_manager(nont_existing_user), None)
 
     def test_get_assignee(self):
-        assignee = get_assignee(self.test_issue)
+        assignee = self.ns.get_assignee(self.test_issue)
         self.assertEqual(assignee.displayName, "Tomas David")
         self.assertEqual(assignee.name, "tdavid@redhat.com")
 
-        empty_assignee = get_assignee(self.jira.issue("OCPBUGS-1542"))
+        empty_assignee = self.ns.get_assignee(self.test_issue_without_assignee)
         self.assertEqual(empty_assignee, None)
 
     def test_create_assignee_notification_text(self):
@@ -108,75 +116,74 @@ class TestJiraNotificator(unittest.TestCase):
         assignee_manager.name = "gjospin"
 
         self.assertEqual(
-            create_assignee_notification_text(Contact.QA_CONTACT, [self.test_user, assignee_manager]),
+            self.ns.create_assignee_notification_text(Contact.QA_CONTACT, [self.test_user, assignee_manager]),
             "Errata Reliability Team Notification - Assignee Action Request\n"
             "This issue has been in the ON_QA state for over 24 hours.\n"
-            "[~tdavid] [~gjospin] The QA contact is missing. Could you please help us identify someone who could review the issue?"
+            "[~tdavid] [~gjospin] The QA contact is missing. Could you please help us identify someone who could verify the issue?"
         )
         self.assertEqual(
-            create_assignee_notification_text(Contact.TEAM_LEAD, [self.test_user, assignee_manager]),
+            self.ns.create_assignee_notification_text(Contact.TEAM_LEAD, [self.test_user, assignee_manager]),
             "Errata Reliability Team Notification - Assignee Action Request\n"
             "This issue has been in the ON_QA state for over 24 hours.\n"
             "[~tdavid] [~gjospin] There has been no response from the QA contact and the Team Lead is not listed in Jira. "
-            "Could you please help us identify someone who could review the issue?"
+            "Could you please help us identify someone who could verify the issue?"
         )
         self.assertEqual(
-            create_assignee_notification_text(Contact.MANAGER, [self.test_user, assignee_manager]),
+            self.ns.create_assignee_notification_text(Contact.MANAGER, [self.test_user, assignee_manager]),
             "Errata Reliability Team Notification - Assignee Action Request\n"
             "This issue has been in the ON_QA state for over 24 hours.\n"
             "[~tdavid] [~gjospin] There has been no response from the QA contact and the Manager is not listed in Jira. "
-            "Could you please help us identify someone who could review the issue?"
+            "Could you please help us identify someone who could verify the issue?"
         )
 
     def test_has_assignee_notification(self):
-        self.assertTrue(has_assignee_notification(self.test_issue))
-        self.assertFalse(has_assignee_notification(self.test_issues_without_qa))
+        self.assertTrue(self.ns.has_assignee_notification(self.test_issue))
+        self.assertFalse(self.ns.has_assignee_notification(self.test_issue_without_qa))
    
     def test_notify_assignees(self):
-        self.assertEqual(notify_assignees(self.jira, self.test_issue, Contact.QA_CONTACT, True), None)
-        self.assertEqual(notify_assignees(self.jira, self.test_issue, Contact.TEAM_LEAD, True), None)
-        self.assertEqual(notify_assignees(self.jira, self.test_issue, Contact.MANAGER, True), None)
+        self.assertEqual(self.ns.notify_assignees(self.test_issue, Contact.QA_CONTACT), None)
+        self.assertEqual(self.ns.notify_assignees(self.test_issue, Contact.TEAM_LEAD), None)
+        self.assertEqual(self.ns.notify_assignees(self.test_issue, Contact.MANAGER), None)
 
-        q_notification = notify_assignees(self.jira,  self.test_issues_without_qa, Contact.QA_CONTACT, True)
-        self.assertEqual(q_notification.issue, self.test_issues_without_qa)
+        q_notification = self.ns.notify_assignees(self.test_issue_without_qa, Contact.QA_CONTACT)
+        self.assertEqual(q_notification.issue, self.test_issue_without_qa)
         self.assertEqual(q_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(q_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] The QA contact is missing. "
-                "Could you please help us identify someone who could review the issue?"
+                "Could you please help us identify someone who could verify the issue?"
             )
         )
-        t_notification = notify_assignees(self.jira,  self.test_issues_without_qa, Contact.TEAM_LEAD, True)
-        self.assertEqual(t_notification.issue, self.test_issues_without_qa)
+        t_notification = self.ns.notify_assignees(self.test_issue_without_qa, Contact.TEAM_LEAD)
+        self.assertEqual(t_notification.issue, self.test_issue_without_qa)
         self.assertEqual(t_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(t_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] "
                 "There has been no response from the QA contact and the Team Lead is not listed in Jira. "
-                "Could you please help us identify someone who could review the issue?"
+                "Could you please help us identify someone who could verify the issue?"
             )
         )
-        m_notification = notify_assignees(self.jira,  self.test_issues_without_qa, Contact.MANAGER, True)
-        self.assertEqual(m_notification.issue, self.test_issues_without_qa)
+        m_notification = self.ns.notify_assignees(self.test_issue_without_qa, Contact.MANAGER)
+        self.assertEqual(m_notification.issue, self.test_issue_without_qa)
         self.assertEqual(m_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(m_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] "
-                "There has been no response from the QA contact and the Manager is not listed in Jira. Could you please help us identify someone who could review the issue?"
+                "There has been no response from the QA contact and the Manager is not listed in Jira. Could you please help us identify someone who could verify the issue?"
             )
         )
 
-        issue_without_assignee = self.jira.issue("OCPBUGS-1542", expand="changelog")
         with self.assertRaises(Exception) as context:
-            notify_assignees(self.jira, issue_without_assignee, Contact.QA_CONTACT, True)
-        self.assertEqual(str(context.exception), f"No contact is available. Issue {issue_without_assignee.key} does not have assignee.")
+            self.ns.notify_assignees(self.test_issue_without_assignee, Contact.QA_CONTACT)
+        self.assertEqual(str(context.exception), f"No contact is available. Issue {self.test_issue_without_assignee.key} does not have assignee.")
 
     def test_create_qa_notification_text(self):
         self.assertEqual(
-            create_qa_notification_text(self.test_user),
+            self.ns.create_qa_notification_text(self.test_user),
             (
                 "Errata Reliability Team Notification - QA Contact Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
@@ -185,7 +192,7 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
     def test_notify_qa_contact(self):
-        notification = notify_qa_contact(self.jira, self.test_issue, True)
+        notification = self.ns.notify_qa_contact(self.test_issue)
         self.assertEqual(notification.issue, self.test_issue)
         self.assertEqual(notification.type, NotificationType.QA_CONTACT)
         self.assertEqual(notification.text, (
@@ -195,20 +202,20 @@ class TestJiraNotificator(unittest.TestCase):
             )
         )
 
-        no_qa_notification = notify_qa_contact(self.jira, self.test_issues_without_qa, True)
-        self.assertEqual(no_qa_notification.issue, self.test_issues_without_qa)
+        no_qa_notification = self.ns.notify_qa_contact(self.test_issue_without_qa)
+        self.assertEqual(no_qa_notification.issue, self.test_issue_without_qa)
         self.assertEqual(no_qa_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(no_qa_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] The QA contact is missing. "
-                "Could you please help us identify someone who could review the issue?"
+                "Could you please help us identify someone who could verify the issue?"
             )
         )
 
     def test_create_team_lead_notification_text(self):
         self.assertEqual(
-            create_team_lead_notification_text(self.test_user),
+            self.ns.create_team_lead_notification_text(self.test_user),
             (
                 "Errata Reliability Team Notification - Team Lead Action Request\n"
                 "This issue has been in the ON_QA state for over 48 hours.\n"
@@ -217,7 +224,7 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
     def test_notify_team_lead(self):
-        notification = notify_team_lead(self.jira, self.test_issue, True)
+        notification = self.ns.notify_team_lead(self.test_issue)
         self.assertEqual(notification.issue, self.test_issue)
         self.assertEqual(notification.type, NotificationType.TEAM_LEAD)
         self.assertEqual(notification.text, (
@@ -227,20 +234,20 @@ class TestJiraNotificator(unittest.TestCase):
             )
         )
 
-        no_qa_notification = notify_team_lead(self.jira, self.test_issues_without_qa, True)
-        self.assertEqual(no_qa_notification.issue, self.test_issues_without_qa)
+        no_qa_notification = self.ns.notify_team_lead(self.test_issue_without_qa)
+        self.assertEqual(no_qa_notification.issue, self.test_issue_without_qa)
         self.assertEqual(no_qa_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(no_qa_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] The QA contact is missing. "
-                "Could you please help us identify someone who could review the issue?"
+                "Could you please help us identify someone who could verify the issue?"
             )
         )
     
     def test_create_manager_notification_text(self):
         self.assertEqual(
-            create_manager_notification_text(self.test_user),
+            self.ns.create_manager_notification_text(self.test_user),
             (
                 "Errata Reliability Team Notification - Manager Action Request\n"
                 "This issue has been in the ON_QA state for over 72 hours.\n"
@@ -249,7 +256,7 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
     def test_notify_manager(self):
-        notification = notify_manager(self.jira, self.test_issue, True)
+        notification = self.ns.notify_manager(self.test_issue)
         self.assertEqual(notification.issue, self.test_issue)
         self.assertEqual(notification.type, NotificationType.MANAGER)
         self.assertEqual(notification.text, (
@@ -259,69 +266,69 @@ class TestJiraNotificator(unittest.TestCase):
             )
         )
 
-        no_qa_notification = notify_manager(self.jira, self.test_issues_without_qa, True)
-        self.assertEqual(no_qa_notification.issue, self.test_issues_without_qa)
+        no_qa_notification = self.ns.notify_manager(self.test_issue_without_qa)
+        self.assertEqual(no_qa_notification.issue, self.test_issue_without_qa)
         self.assertEqual(no_qa_notification.type, NotificationType.ASSIGNEE)
         self.assertEqual(no_qa_notification.text, (
                 "Errata Reliability Team Notification - Assignee Action Request\n"
                 "This issue has been in the ON_QA state for over 24 hours.\n"
                 "[~rhn-engineering-scollier] [~fsimonce@redhat.com] The QA contact is missing. "
-                "Could you please help us identify someone who could review the issue?"
+                "Could you please help us identify someone who could verify the issue?"
             )
         )
 
     def test_get_latest_on_qa_transition_datetime(self):
         self.assertEqual(
-            get_latest_on_qa_transition_datetime(self.test_issue),
+            self.ns.get_latest_on_qa_transition_datetime(self.test_issue),
             datetime(2025, 7, 15, 14, 10, 20, 862000, timezone.utc)
         )
-        self.assertEqual(get_latest_on_qa_transition_datetime(
-            self.test_issues_without_qa),
+        self.assertEqual(self.ns.get_latest_on_qa_transition_datetime(
+            self.test_issue_without_qa),
             None
         )
 
     def test_get_latest_notification_dates_after_on_qa_transition(self):
-        all_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 9, 0, 0, 0, timezone.utc))
+        all_notifications = self.ns.get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 9, 0, 0, 0, timezone.utc))
         self.assertEqual(all_notifications.get(NotificationType.QA_CONTACT), datetime(2025, 7, 17, 11, 8, 46, 381000, timezone.utc))
         self.assertEqual(all_notifications.get(NotificationType.TEAM_LEAD), datetime(2025, 7, 17, 11, 10, 25, 168000, timezone.utc))
         self.assertEqual(all_notifications.get(NotificationType.MANAGER), datetime(2025, 7, 17, 11, 11, 54, 48000, timezone.utc))
         self.assertEqual(all_notifications.get(NotificationType.ASSIGNEE), datetime(2025, 7, 17, 9, 53, 50, 10000, timezone.utc))
 
-        partial_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 9, 0, 0, timezone.utc))
+        partial_notifications = self.ns.get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 9, 0, 0, timezone.utc))
         self.assertEqual(partial_notifications.get(NotificationType.QA_CONTACT), None)
         self.assertEqual(partial_notifications.get(NotificationType.TEAM_LEAD), datetime(2025, 7, 17, 11, 10, 25, 168000, timezone.utc))
         self.assertEqual(partial_notifications.get(NotificationType.MANAGER), datetime(2025, 7, 17, 11, 11, 54, 48000, timezone.utc))
         self.assertEqual(partial_notifications.get(NotificationType.ASSIGNEE), None)
 
-        none_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 12, 0, 0, timezone.utc))
+        none_notifications = self.ns.get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 12, 0, 0, timezone.utc))
         self.assertEqual(len(none_notifications), 0)
 
     def test_is_more_than_24_weekday_hours(self):
         start = datetime(2025, 7, 22, 10, tzinfo=timezone.utc)
-        self.assertFalse(is_more_than_24_weekday_hours(start, start + timedelta(hours=23)))
-        self.assertFalse(is_more_than_24_weekday_hours(start,  start + timedelta(hours=24)))
-        self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=24, minutes=1)))
-        self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=25)))
+        self.assertFalse(self.ns.is_more_than_24_weekday_hours(start, start + timedelta(hours=23)))
+        self.assertFalse(self.ns.is_more_than_24_weekday_hours(start,  start + timedelta(hours=24)))
+        self.assertTrue(self.ns.is_more_than_24_weekday_hours(start, start + timedelta(hours=24, minutes=1)))
+        self.assertTrue(self.ns.is_more_than_24_weekday_hours(start, start + timedelta(hours=25)))
 
         friday_start = datetime(2025, 7, 18, 10, tzinfo=timezone.utc)
-        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 9, tzinfo=timezone.utc)))
-        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, tzinfo=timezone.utc)))
-        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, 1, tzinfo=timezone.utc)))
-        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 11, tzinfo=timezone.utc)))
+        self.assertFalse(self.ns.is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 9, tzinfo=timezone.utc)))
+        self.assertFalse(self.ns.is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, tzinfo=timezone.utc)))
+        self.assertTrue(self.ns.is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, 1, tzinfo=timezone.utc)))
+        self.assertTrue(self.ns.is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 11, tzinfo=timezone.utc)))
 
-        self.assertFalse(is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=23)))
-        self.assertTrue(is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=73)))
+        self.assertFalse(self.ns.is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=23)))
+        self.assertTrue(self.ns.is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=73)))
 
     def test_get_on_qa_filter(self):
         self.assertEqual(
-            get_on_qa_filter(None),
+            self.ns.get_on_qa_filter(None),
             (
                 "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
                 "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
             )
         )
         self.assertEqual(
-            get_on_qa_filter(datetime(2025, 7, 17, tzinfo=timezone.utc)),
+            self.ns.get_on_qa_filter(datetime(2025, 7, 17, tzinfo=timezone.utc)),
             (
                 "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
                 "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
@@ -330,12 +337,12 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
     def test_get_on_qa_issues(self):
-        issues = get_on_qa_issues(self.jira, 100, None)
+        issues = self.ns.get_on_qa_issues(100, None)
         self.assertNotEqual(len(issues), 0)
         for i in issues:
             self.assertTrue(i.key.startswith("OCPBUGS-"))
 
-        issues_after_date = get_on_qa_issues(self.jira, 100, datetime(2025, 7, 17, tzinfo=timezone.utc))
+        issues_after_date = self.ns.get_on_qa_issues(100, datetime(2025, 7, 17, tzinfo=timezone.utc))
         self.assertNotEqual(len(issues_after_date), 0)
         self.assertGreater(len(issues), len(issues_after_date))
         for iad in issues_after_date:

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -10,22 +10,51 @@ class TestJiraNotificator(unittest.TestCase):
     def setUp(self):
         jira_token = os.environ.get("JIRA_TOKEN")
         self.jira = JIRA(server="https://issues.redhat.com", token_auth=jira_token)
-    
-    def test_notification_type(self):
+        self.test_issue = self.jira.issue("OCPBUGS-59288", expand="changelog")
+        self.test_issues_without_qa = self.jira.issue("OCPBUGS-8760", expand="changelog")
+
+    def test_create_notification_title(self):
+        self.assertEqual(
+            create_notification_title(NotificationType.QA_CONTACT),
+            (
+                "Errata Reliability Team Notification - QA Contact Action Request\n"
+                "This issue has been in the ON_QA state for over 24 hours."
+            )
+        )
+        self.assertEqual(
+            create_notification_title(NotificationType.TEAM_LEAD),
+            (
+                "Errata Reliability Team Notification - Team Lead Action Request\n"
+                "This issue has been in the ON_QA state for over 48 hours."
+            )
+        )
+        self.assertEqual(
+            create_notification_title(NotificationType.MANAGER),
+            (
+                "Errata Reliability Team Notification - Manager Action Request\n"
+                "This issue has been in the ON_QA state for over 72 hours."
+            )
+            
+        )
+
+    def test_get_notification_type(self):
         self.assertEqual(get_notification_type("QA Contact Action Request"), NotificationType.QA_CONTACT)
         self.assertEqual(get_notification_type("Team Lead Action Request"), NotificationType.TEAM_LEAD)
         self.assertEqual(get_notification_type("Manager Action Request"), NotificationType.MANAGER)
         self.assertEqual(get_notification_type("Please verify the issues as soon as possible."), None)
+        self.assertEqual(get_notification_type("QA Contact Manager Team Lead"), None)
         self.assertEqual(get_notification_type(""), None)
 
+    def test_find_user_by_email(self):
+        self.assertEqual(find_user_by_email(self.jira, "tdavid@redhat.com").displayName, "Tomas David")
+        self.assertEqual(find_user_by_email(self.jira, "dtomas@redhat.com"), None)
+
     def test_get_qa_contact(self):
-        issue = self.jira.issue("OCPBUGS-59288", expand="changelog")
-        qa_contact = get_qa_contact(issue)
+        qa_contact = get_qa_contact(self.test_issue)
         self.assertEqual(qa_contact.displayName, "Tomas David")
         self.assertEqual(qa_contact.name, "tdavid@redhat.com")
 
-        issues_without_qa = self.jira.issue("OCPBUGS-8760", expand="changelog")
-        self.assertEqual(get_qa_contact(issues_without_qa), None)
+        self.assertEqual(get_qa_contact(self.test_issues_without_qa), None)
 
     def test_get_manager(self):
         qa_contact = Mock()
@@ -38,72 +67,68 @@ class TestJiraNotificator(unittest.TestCase):
         invalid_user.emailAddress = "dtomas@redhat.com"
         self.assertEqual(get_manager(self.jira, invalid_user), None)
 
-    def test_find_user_by_email(self):
-        self.assertEqual(find_user_by_email(self.jira, "tdavid@redhat.com").displayName, "Tomas David")
-        self.assertEqual(find_user_by_email(self.jira, "dtomas@redhat.com"), None)
-    
-
-    def test_create_notification_prefix(self):
-        self.assertEqual(
-            create_notification_prefix(NotificationType.QA_CONTACT),
-            "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours."
-        )
-        self.assertEqual(
-            create_notification_prefix(NotificationType.TEAM_LEAD),
-            "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours."
-        )
-        self.assertEqual(
-            create_notification_prefix(NotificationType.MANAGER),
-            "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours."
-        )
-
     def test_create_qa_notification_text(self):
         self.assertEqual(
-            create_qa_notification_text(self.jira.issue("OCPBUGS-59288", expand="changelog")),
+            create_qa_notification_text(self.test_issue),
             (
-                "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours. "
-                "[~tdavid@redhat.com] Please verify the Jira as soon as possible."
+                "Errata Reliability Team Notification - QA Contact Action Request\n"
+                "This issue has been in the ON_QA state for over 24 hours.\n"
+                "[~tdavid@redhat.com] Please verify the Jira ticket as soon as possible."
             )
         )
         self.assertEqual(
-            create_qa_notification_text(self.jira.issue("OCPBUGS-8760", expand="changelog")),
+            create_qa_notification_text(self.test_issues_without_qa),
             (
-                "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours. "
-                "Please verify the Jira as soon as possible."
+                "Errata Reliability Team Notification - QA Contact Action Request\n"
+                "This issue has been in the ON_QA state for over 24 hours.\n"
+                "Please verify the Jira ticket as soon as possible."
             )
         )
-    
+
     def test_create_team_lead_notification_text(self):
         self.assertEqual(
             create_team_lead_notification_text(self.jira.issue("OCPBUGS-59288", expand="changelog")),
             (
-                "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours. "
-                "[~tdavid@redhat.com] Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+                "Errata Reliability Team Notification - Team Lead Action Request\n"
+                "This issue has been in the ON_QA state for over 48 hours.\n"
+                "[~tdavid@redhat.com] Please verify the Jira ticket as soon as possible or arrange a reassignment with your team lead."
             )
         )
         self.assertEqual(
             create_team_lead_notification_text(self.jira.issue("OCPBUGS-8760", expand="changelog")),
             (
-                "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours. "
-                "Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+                "Errata Reliability Team Notification - Team Lead Action Request\n"
+                "This issue has been in the ON_QA state for over 48 hours.\n"
+                "Please verify the Jira ticket as soon as possible or arrange a reassignment with your team lead."
             )
         )
-    
+
     def test_create_manager_notification_text(self):
         self.assertEqual(
             create_manager_notification_text(self.jira, self.jira.issue("OCPBUGS-59288", expand="changelog")),
             (
-                "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours. "
-                "[~rhn-support-gjospin] Please prioritize the verification or consider reassigning it to another available QA Contact."
+                "Errata Reliability Team Notification - Manager Action Request\n"
+                "This issue has been in the ON_QA state for over 72 hours.\n"
+                "[~rhn-support-gjospin] Please prioritize the Jira ticket verification or consider reassigning it to another available QA Contact."
             )
         )
         self.assertEqual(
             create_manager_notification_text(self.jira, self.jira.issue("OCPBUGS-8760", expand="changelog")),
             (
-                "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours. "
-                "Please prioritize the verification or consider reassigning it to another available QA Contact."
+                "Errata Reliability Team Notification - Manager Action Request\n"
+                "This issue has been in the ON_QA state for over 72 hours.\n"
+                "Please prioritize the Jira ticket verification or consider reassigning it to another available QA Contact."
             )
         )
+
+    def test_get_latest_on_qa_transition_datetime(self):
+        self.assertEqual(get_latest_on_qa_transition_datetime(self.test_issue), datetime(2025, 7, 15, 14, 10, 20, 862000, timezone.utc))
+        self.assertEqual(get_latest_on_qa_transition_datetime(self.test_issues_without_qa), None)
+
+    def test_get_latest_ert_notification_type_after_on_qa_transition(self):
+        self.assertEqual(get_latest_ert_notification_type_after_on_qa_transition(self.test_issue, datetime(2025, 7, 15, 14, 50, 0, 0, timezone.utc)), NotificationType.TEAM_LEAD)
+        self.assertEqual(get_latest_ert_notification_type_after_on_qa_transition(self.test_issue, datetime(2025, 7, 15, 14, 52, 0, 0, timezone.utc)), None)
+        self.assertEqual(get_latest_ert_notification_type_after_on_qa_transition(self.test_issues_without_qa, datetime(2024, 1, 1, 1, 1, 0, 0, timezone.utc)), None)
 
     def test_get_on_qa_issues(self):
         issues = get_on_qa_issues(self.jira)

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -131,7 +131,7 @@ class TestJiraNotificator(unittest.TestCase):
         self.assertEqual(get_latest_ert_notification_type_after_on_qa_transition(self.test_issues_without_qa, datetime(2024, 1, 1, 1, 1, 0, 0, timezone.utc)), None)
 
     def test_get_on_qa_issues(self):
-        issues = get_on_qa_issues(self.jira)
+        issues = get_on_qa_issues(self.jira, 100)
         self.assertNotEqual(len(issues), 0)
         for i in issues:
             self.assertTrue(i.key.startswith("OCPBUGS-"))

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -1,0 +1,112 @@
+import os
+import unittest
+
+from unittest.mock import Mock
+
+from tools.jira_notificator import *
+
+class TestJiraNotificator(unittest.TestCase):
+
+    def setUp(self):
+        jira_token = os.environ.get("JIRA_TOKEN")
+        self.jira = JIRA(server="https://issues.redhat.com", token_auth=jira_token)
+    
+    def test_notification_type(self):
+        self.assertEqual(get_notification_type("QA Contact Action Request"), NotificationType.QA_CONTACT)
+        self.assertEqual(get_notification_type("Team Lead Action Request"), NotificationType.TEAM_LEAD)
+        self.assertEqual(get_notification_type("Manager Action Request"), NotificationType.MANAGER)
+        self.assertEqual(get_notification_type("Please verify the issues as soon as possible."), None)
+        self.assertEqual(get_notification_type(""), None)
+
+    def test_get_qa_contact(self):
+        issue = self.jira.issue("OCPBUGS-59288", expand="changelog")
+        qa_contact = get_qa_contact(issue)
+        self.assertEqual(qa_contact.displayName, "Tomas David")
+        self.assertEqual(qa_contact.name, "tdavid@redhat.com")
+
+        issues_without_qa = self.jira.issue("OCPBUGS-8760", expand="changelog")
+        self.assertEqual(get_qa_contact(issues_without_qa), None)
+
+    def test_get_manager(self):
+        qa_contact = Mock()
+        qa_contact.emailAddress = "tdavid@redhat.com"
+        manager = get_manager(self.jira, qa_contact)
+        self.assertEqual(manager.displayName, "Gui Jospin")
+        self.assertEqual(manager.name, "rhn-support-gjospin")
+
+        invalid_user = Mock()
+        invalid_user.emailAddress = "dtomas@redhat.com"
+        self.assertEqual(get_manager(self.jira, invalid_user), None)
+
+    def test_find_user_by_email(self):
+        self.assertEqual(find_user_by_email(self.jira, "tdavid@redhat.com").displayName, "Tomas David")
+        self.assertEqual(find_user_by_email(self.jira, "dtomas@redhat.com"), None)
+    
+
+    def test_create_notification_prefix(self):
+        self.assertEqual(
+            create_notification_prefix(NotificationType.QA_CONTACT),
+            "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours."
+        )
+        self.assertEqual(
+            create_notification_prefix(NotificationType.TEAM_LEAD),
+            "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours."
+        )
+        self.assertEqual(
+            create_notification_prefix(NotificationType.MANAGER),
+            "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours."
+        )
+
+    def test_create_qa_notification_text(self):
+        self.assertEqual(
+            create_qa_notification_text(self.jira.issue("OCPBUGS-59288", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours. "
+                "[~tdavid@redhat.com] Please verify the Jira as soon as possible."
+            )
+        )
+        self.assertEqual(
+            create_qa_notification_text(self.jira.issue("OCPBUGS-8760", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - QA Contact Action Request: This issue has been in the ON_QA state for over 24 hours. "
+                "Please verify the Jira as soon as possible."
+            )
+        )
+    
+    def test_create_team_lead_notification_text(self):
+        self.assertEqual(
+            create_team_lead_notification_text(self.jira.issue("OCPBUGS-59288", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours. "
+                "[~tdavid@redhat.com] Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+            )
+        )
+        self.assertEqual(
+            create_team_lead_notification_text(self.jira.issue("OCPBUGS-8760", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - Team Lead Action Request: This issue has been in the ON_QA state for over 48 hours. "
+                "Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+            )
+        )
+    
+    def test_create_manager_notification_text(self):
+        self.assertEqual(
+            create_manager_notification_text(self.jira, self.jira.issue("OCPBUGS-59288", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours. "
+                "[~rhn-support-gjospin] Please prioritize the verification or consider reassigning it to another available QA Contact."
+            )
+        )
+        self.assertEqual(
+            create_manager_notification_text(self.jira, self.jira.issue("OCPBUGS-8760", expand="changelog")),
+            (
+                "Errata Reliability Team Notification - Manager Action Request: This issue has been in the ON_QA state for over 72 hours. "
+                "Please prioritize the verification or consider reassigning it to another available QA Contact."
+            )
+        )
+
+    def test_get_on_qa_issues(self):
+        issues = get_on_qa_issues(self.jira)
+        self.assertNotEqual(len(issues), 0)
+        for i in issues:
+            self.assertTrue(i.key.startswith("OCPBUGS-"))

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -188,25 +188,21 @@ class TestJiraNotificator(unittest.TestCase):
             None
         )
 
-    def test_get_latest_ert_notification_type_after_on_qa_transition(self):
-        self.assertEqual(
-            get_latest_ert_notification_type_after_on_qa_transition(
-                self.test_issue, datetime(2025, 7, 17, 11, 10, 0, 0, timezone.utc)
-            ), 
-            NotificationType.MANAGER
-        )
-        self.assertEqual(
-            get_latest_ert_notification_type_after_on_qa_transition(
-                self.test_issue, datetime(2025, 7, 17, 11, 12, 0, 0, timezone.utc)
-            ),
-            None
-        )
-        self.assertEqual(
-            get_latest_ert_notification_type_after_on_qa_transition(
-                self.test_issues_without_qa, datetime(2024, 1, 1, 1, 1, 0, 0, timezone.utc)
-            ),
-            None
-        )
+    def test_get_latest_notification_dates_after_on_qa_transition(self):
+        all_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 9, 0, 0, 0, timezone.utc))
+        self.assertEqual(all_notifications.get(NotificationType.QA_CONTACT), datetime(2025, 7, 17, 11, 8, 46, 381000, timezone.utc))
+        self.assertEqual(all_notifications.get(NotificationType.TEAM_LEAD), datetime(2025, 7, 17, 11, 10, 25, 168000, timezone.utc))
+        self.assertEqual(all_notifications.get(NotificationType.MANAGER), datetime(2025, 7, 17, 11, 11, 54, 48000, timezone.utc))
+        self.assertEqual(all_notifications.get(NotificationType.ASSIGNEE), datetime(2025, 7, 17, 9, 53, 50, 10000, timezone.utc))
+
+        partial_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 9, 0, 0, timezone.utc))
+        self.assertEqual(partial_notifications.get(NotificationType.QA_CONTACT), None)
+        self.assertEqual(partial_notifications.get(NotificationType.TEAM_LEAD), datetime(2025, 7, 17, 11, 10, 25, 168000, timezone.utc))
+        self.assertEqual(partial_notifications.get(NotificationType.MANAGER), datetime(2025, 7, 17, 11, 11, 54, 48000, timezone.utc))
+        self.assertEqual(partial_notifications.get(NotificationType.ASSIGNEE), None)
+
+        none_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 12, 0, 0, timezone.utc))
+        self.assertEqual(len(none_notifications), 0)
 
     def test_get_on_qa_filter(self):
         self.assertEqual(

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -205,20 +205,20 @@ class TestJiraNotificator(unittest.TestCase):
         self.assertEqual(len(none_notifications), 0)
 
     def test_is_more_than_24_weekday_hours(self):
-        start = datetime(2025, 7, 22, 10)
+        start = datetime(2025, 7, 22, 10, tzinfo=timezone.utc)
         self.assertFalse(is_more_than_24_weekday_hours(start, start + timedelta(hours=23)))
         self.assertFalse(is_more_than_24_weekday_hours(start,  start + timedelta(hours=24)))
         self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=24, minutes=1)))
         self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=25)))
 
-        friday_start = datetime(2025, 7, 18, 10)
-        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 9)))
-        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10)))
-        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, 1)))
-        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 11)))
+        friday_start = datetime(2025, 7, 18, 10, tzinfo=timezone.utc)
+        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 9, tzinfo=timezone.utc)))
+        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, tzinfo=timezone.utc)))
+        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, 1, tzinfo=timezone.utc)))
+        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 11, tzinfo=timezone.utc)))
 
-        self.assertFalse(is_more_than_24_weekday_hours(datetime.now() - timedelta(hours=23)))
-        self.assertTrue(is_more_than_24_weekday_hours(datetime.now() - timedelta(hours=73)))
+        self.assertFalse(is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=23)))
+        self.assertTrue(is_more_than_24_weekday_hours(datetime.now(timezone.utc) - timedelta(hours=73)))
 
     def test_get_on_qa_filter(self):
         self.assertEqual(
@@ -229,7 +229,7 @@ class TestJiraNotificator(unittest.TestCase):
             )
         )
         self.assertEqual(
-            get_on_qa_filter(datetime(2025, 7, 17)),
+            get_on_qa_filter(datetime(2025, 7, 17, tzinfo=timezone.utc)),
             (
                 "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
                 "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
@@ -243,7 +243,7 @@ class TestJiraNotificator(unittest.TestCase):
         for i in issues:
             self.assertTrue(i.key.startswith("OCPBUGS-"))
 
-        issues_after_date = get_on_qa_issues(self.jira, 100, datetime(2025, 7, 17))
+        issues_after_date = get_on_qa_issues(self.jira, 100, datetime(2025, 7, 17, tzinfo=timezone.utc))
         self.assertNotEqual(len(issues_after_date), 0)
         self.assertGreater(len(issues), len(issues_after_date))
         for iad in issues_after_date:

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -208,8 +208,31 @@ class TestJiraNotificator(unittest.TestCase):
             None
         )
 
+    def test_get_on_qa_filter(self):
+        self.assertEqual(
+            get_on_qa_filter(None),
+            (
+                "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
+                "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
+            )
+        )
+        self.assertEqual(
+            get_on_qa_filter(datetime(2025, 7, 17)),
+            (
+                "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
+                "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
+                " AND status changed to ON_QA after 2025-07-17"
+            )
+        )
+
     def test_get_on_qa_issues(self):
-        issues = get_on_qa_issues(self.jira, 100)
+        issues = get_on_qa_issues(self.jira, 100, None)
         self.assertNotEqual(len(issues), 0)
         for i in issues:
             self.assertTrue(i.key.startswith("OCPBUGS-"))
+
+        issues_after_date = get_on_qa_issues(self.jira, 100, datetime(2025, 7, 17))
+        self.assertNotEqual(len(issues_after_date), 0)
+        self.assertGreater(len(issues), len(issues_after_date))
+        for iad in issues_after_date:
+            self.assertTrue(iad.key.startswith("OCPBUGS-"))

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -204,6 +204,22 @@ class TestJiraNotificator(unittest.TestCase):
         none_notifications = get_latest_notification_dates_after_on_qa_transition(self.test_issue, datetime(2025, 7, 17, 11, 12, 0, 0, timezone.utc))
         self.assertEqual(len(none_notifications), 0)
 
+    def test_is_more_than_24_weekday_hours(self):
+        start = datetime(2025, 7, 22, 10)
+        self.assertFalse(is_more_than_24_weekday_hours(start, start + timedelta(hours=23)))
+        self.assertFalse(is_more_than_24_weekday_hours(start,  start + timedelta(hours=24)))
+        self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=24, minutes=1)))
+        self.assertTrue(is_more_than_24_weekday_hours(start, start + timedelta(hours=25)))
+
+        friday_start = datetime(2025, 7, 18, 10)
+        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 9)))
+        self.assertFalse(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10)))
+        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 10, 1)))
+        self.assertTrue(is_more_than_24_weekday_hours(friday_start, datetime(2025, 7, 21, 11)))
+
+        self.assertFalse(is_more_than_24_weekday_hours(datetime.now() - timedelta(hours=23)))
+        self.assertTrue(is_more_than_24_weekday_hours(datetime.now() - timedelta(hours=73)))
+
     def test_get_on_qa_filter(self):
         self.assertEqual(
             get_on_qa_filter(None),

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -68,6 +68,7 @@ class NotificationService:
     def __init__(self, jira, dry_run=False):
         self.jira = jira
         self.dry_run = dry_run
+        self.ldap = LdapHelper()
 
     def create_notification_title(self, notification_type: NotificationType) -> str:
         """
@@ -178,8 +179,7 @@ class NotificationService:
             Optional[User]: The manager user if found, otherwise None.
         """
 
-        ldap = LdapHelper()
-        manager_email = ldap.get_manager_email(user.emailAddress)
+        manager_email = self.ldap.get_manager_email(user.emailAddress)
         if manager_email:
             manager = self.find_user_by_email(manager_email)
             if manager:

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -21,8 +21,11 @@ class NotificationType(Enum):
         self.hours = hours
         self.label = label
 
-def create_notification_prefix(notification_type: NotificationType) -> str:
-    return f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}: This issue has been in the ON_QA state for over {notification_type.hours} hours."
+def create_notification_title(notification_type: NotificationType) -> str:
+    return (
+        f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}\n"
+        f"This issue has been in the ON_QA state for over {notification_type.hours} hours."
+    )
 
 def get_notification_type(notification_message: str) -> Optional[NotificationType]:
     for notification_type in NotificationType:
@@ -30,7 +33,7 @@ def get_notification_type(notification_message: str) -> Optional[NotificationTyp
             return notification_type
     return None
 
-def find_user_by_email(jira: JIRA, email) -> Optional[User]:
+def find_user_by_email(jira: JIRA, email: str) -> Optional[User]:
     for user in jira.search_users(user=email):
         if user.emailAddress == email:
             return user
@@ -42,7 +45,7 @@ def get_qa_contact(issue: Issue) -> Optional[User]:
     if qa_contact:
         return qa_contact
     else:
-        logger.warning(f"Issue {issue.key} does not have QA contact.")
+        logger.warning(f"Issue {issue.key} does not have a QA contact.")
         return None
 
 def get_manager(jira: JIRA, qa_contact: User) -> Optional[User]:
@@ -53,24 +56,31 @@ def get_manager(jira: JIRA, qa_contact: User) -> Optional[User]:
         if manager:
             return manager
         else:
-            logger.warning("Notification to QA Contact Manager could not be sent because manager user was not found in Jira.")
-    
+            logger.warning(f"Manager {manager_email} was not found in Jira.")
     else:
-        logger.warning("Notification to QA Contact Manager could not be sent because QA contact manager was not found.")
+        logger.warning(f"Manager of QA contact {qa_contact.emailAddress} was not found in LDAP.")
     return None
 
 def create_qa_notification_text(issue: Issue)  -> str:
+    qa_contact_link = ""
     qa_contact = get_qa_contact(issue)
-    qa_contact_link = f"[~{qa_contact.name}] " if qa_contact else ""
-    return f"{create_notification_prefix(NotificationType.QA_CONTACT)} {qa_contact_link}Please verify the Jira as soon as possible."
+    if qa_contact:
+        qa_contact_link = f"[~{qa_contact.name}] "
+    else:
+        logger.warning(f"Notification text was generated without a link to the QA Contact for Jira ticket {issue.key}.")
+    return f"{create_notification_title(NotificationType.QA_CONTACT)}\n{qa_contact_link}Please verify the Jira ticket as soon as possible."
 
 def notify_qa_contact(jira: JIRA, issue: Issue) -> None:
     jira.add_comment(issue, create_qa_notification_text(issue))
 
 def create_team_lead_notification_text(issue: Issue) -> str:
+    qa_contact_link = ""
     qa_contact = get_qa_contact(issue)
-    qa_contact_link = f"[~{qa_contact.name}] " if qa_contact else ""
-    return f"{create_notification_prefix(NotificationType.TEAM_LEAD)} {qa_contact_link}Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+    if qa_contact:
+        qa_contact_link = f"[~{qa_contact.name}] "
+    else:
+        logger.warning(f"Notification text was generated without a link to the QA Contact for Jira ticket {issue.key}.")
+    return f"{create_notification_title(NotificationType.TEAM_LEAD)}\n{qa_contact_link}Please verify the Jira ticket as soon as possible or arrange a reassignment with your team lead."
 
 def notify_team_lead(jira: JIRA, issue: Issue) -> None:
     logger.info("Notification to the team lead is not yet implemented. Notifying the QA contact again.")
@@ -81,10 +91,13 @@ def create_manager_notification_text(jira: JIRA, issue: Issue) -> str:
     manager_link = ""
     if qa_contact:
         manager = get_manager(jira, qa_contact)
-        manager_link = f"[~{manager.name}] " if manager else ""
+        if manager:
+            manager_link = f"[~{manager.name}] "
+        else:
+            logger.warning(f"Notification text was generated without a link to the Manager for Jira ticket {issue.key} (Missing Manager).")
     else:
-        logger.warning("Notification to QA Contact Manager could not be sent because of missing QA contact.")
-    return f"{create_notification_prefix(NotificationType.MANAGER)} {manager_link}Please prioritize the verification or consider reassigning it to another available QA Contact."
+        logger.warning(f"Notification text was generated without a link to the Manager for Jira ticket {issue.key} (Missing QA Contact).")
+    return f"{create_notification_title(NotificationType.MANAGER)}\n{manager_link}Please prioritize the Jira ticket verification or consider reassigning it to another available QA Contact."
 
 def notify_manager(jira: JIRA, issue: Issue) -> None:
     jira.add_comment(issue, create_manager_notification_text(jira, issue))
@@ -105,8 +118,8 @@ def get_latest_on_qa_transition_datetime(issue: Issue) -> Optional[datetime]:
     return latest_on_qa
 
 def get_latest_ert_notification_type_after_on_qa_transition(issue: Issue, on_qa_transition: datetime) -> Optional[NotificationType]:
-    latest_notification_type = None
-    latest_datetime = None
+    latest_notification_type: NotificationType = None
+    latest_datetime: datetime = None
 
     for comment in issue.fields.comment.comments:
         if not comment.body.startswith(ERT_NOTIFICATION_PREFIX):
@@ -142,15 +155,15 @@ def check_issue_and_notify_responsible_people(jira: JIRA, issue: Issue) -> None:
             notify_qa_contact(jira, issue)
 
 def get_on_qa_issues(jira: JIRA) -> list[Issue]:
-    ON_QA_ISSUES_FILTER = "project = OCPBUGS AND issuetype in (Bug, Vulnerability) AND status = ON_QA AND affectedVersion in (4.12.z, 4.13.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
+    ON_QA_ISSUES_FILTER = "project = OCPBUGS AND issuetype in (Bug, Vulnerability) AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
 
     start_at = 0
-    max_results = 100
+    batch_size = 100
     on_qa_issues = []
 
     while True:
         issues = jira.search_issues(
-            ON_QA_ISSUES_FILTER, startAt=start_at, maxResults=max_results, expand="changelog"
+            ON_QA_ISSUES_FILTER, startAt=start_at, maxResults=batch_size, expand="changelog"
         )
         if not issues:
             break

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -241,7 +241,7 @@ def get_latest_notification_dates_after_on_qa_transition(issue: Issue, on_qa_tra
 
 def is_more_than_24_weekday_hours(from_date: datetime, now: Optional[datetime] = None) -> bool:
     if now is None:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
     if from_date >= now:
         return False

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -1,0 +1,164 @@
+import logging
+
+from enum import Enum
+from typing import Optional
+from jira import JIRA, Issue
+from jira.resources import User
+from datetime import datetime, timedelta, timezone
+from dateutil import parser
+from oar.core.ldap import LdapHelper
+
+logger = logging.getLogger(__name__)
+
+ERT_NOTIFICATION_PREFIX = "Errata Reliability Team Notification"
+
+class NotificationType(Enum):
+    QA_CONTACT = (24, "QA Contact Action Request")
+    TEAM_LEAD = (48, "Team Lead Action Request")
+    MANAGER = (72, "Manager Action Request")
+
+    def __init__(self, hours: int, label: str):
+        self.hours = hours
+        self.label = label
+
+def create_notification_prefix(notification_type: NotificationType) -> str:
+    return f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}: This issue has been in the ON_QA state for over {notification_type.hours} hours."
+
+def get_notification_type(notification_message: str) -> Optional[NotificationType]:
+    for notification_type in NotificationType:
+        if notification_type.label in notification_message:
+            return notification_type
+    return None
+
+def find_user_by_email(jira: JIRA, email) -> Optional[User]:
+    for user in jira.search_users(user=email):
+        if user.emailAddress == email:
+            return user
+    logger.warning(f"User was not found for email {email}.")
+    return None
+
+def get_qa_contact(issue: Issue) -> Optional[User]:
+    qa_contact = issue.fields.customfield_12315948
+    if qa_contact:
+        return qa_contact
+    else:
+        logger.warning(f"Issue {issue.key} does not have QA contact.")
+        return None
+
+def get_manager(jira: JIRA, qa_contact: User) -> Optional[User]:
+    ldap = LdapHelper()
+    manager_email = ldap.get_manager_email(qa_contact.emailAddress)
+    if manager_email:
+        manager = find_user_by_email(jira, manager_email)
+        if manager:
+            return manager
+        else:
+            logger.warning("Notification to QA Contact Manager could not be sent because manager user was not found in Jira.")
+    
+    else:
+        logger.warning("Notification to QA Contact Manager could not be sent because QA contact manager was not found.")
+    return None
+
+def create_qa_notification_text(issue: Issue)  -> str:
+    qa_contact = get_qa_contact(issue)
+    qa_contact_link = f"[~{qa_contact.name}] " if qa_contact else ""
+    return f"{create_notification_prefix(NotificationType.QA_CONTACT)} {qa_contact_link}Please verify the Jira as soon as possible."
+
+def notify_qa_contact(jira: JIRA, issue: Issue) -> None:
+    jira.add_comment(issue, create_qa_notification_text(issue))
+
+def create_team_lead_notification_text(issue: Issue) -> str:
+    qa_contact = get_qa_contact(issue)
+    qa_contact_link = f"[~{qa_contact.name}] " if qa_contact else ""
+    return f"{create_notification_prefix(NotificationType.TEAM_LEAD)} {qa_contact_link}Please verify the Jira as soon as possible or arrange a reassignment with your team lead."
+
+def notify_team_lead(jira: JIRA, issue: Issue) -> None:
+    logger.info("Notification to the team lead is not yet implemented. Notifying the QA contact again.")
+    jira.add_comment(issue, create_team_lead_notification_text(issue))
+
+def create_manager_notification_text(jira: JIRA, issue: Issue) -> str:
+    qa_contact = get_qa_contact(issue)
+    manager_link = ""
+    if qa_contact:
+        manager = get_manager(jira, qa_contact)
+        manager_link = f"[~{manager.name}] " if manager else ""
+    else:
+        logger.warning("Notification to QA Contact Manager could not be sent because of missing QA contact.")
+    return f"{create_notification_prefix(NotificationType.MANAGER)} {manager_link}Please prioritize the verification or consider reassigning it to another available QA Contact."
+
+def notify_manager(jira: JIRA, issue: Issue) -> None:
+    jira.add_comment(issue, create_manager_notification_text(jira, issue))
+   
+def get_latest_on_qa_transition_datetime(issue: Issue) -> Optional[datetime]:
+    latest_on_qa: datetime = None
+
+    for history in issue.changelog.histories:
+        for item in history.items:
+            if item.field == "status" and item.toString == "ON_QA":
+                transition_time = parser.parse(history.created)
+                if not latest_on_qa or transition_time > latest_on_qa:
+                    latest_on_qa = transition_time
+
+    if not latest_on_qa:
+        logger.error(f"Issue {issue.key} does not have ON_QA transition date")
+
+    return latest_on_qa
+
+def get_latest_ert_notification_type_after_on_qa_transition(issue: Issue, on_qa_transition: datetime) -> Optional[NotificationType]:
+    latest_notification_type = None
+    latest_datetime = None
+
+    for comment in issue.fields.comment.comments:
+        if not comment.body.startswith(ERT_NOTIFICATION_PREFIX):
+            continue
+
+        created_datetime = parser.parse(comment.created)
+        if created_datetime < on_qa_transition:
+            continue
+
+        if not latest_datetime or created_datetime > latest_datetime:
+            latest_datetime = created_datetime
+            latest_notification_type = get_notification_type(comment.body)
+
+    return latest_notification_type
+
+
+def check_issue_and_notify_responsible_people(jira: JIRA, issue: Issue) -> None:
+    on_qa_datetime = get_latest_on_qa_transition_datetime(issue)
+    if not on_qa_datetime:
+        return
+
+    delta = datetime.now(timezone.utc) - on_qa_datetime
+    latest_notification_type = get_latest_ert_notification_type_after_on_qa_transition(issue, on_qa_datetime)
+
+    if delta > timedelta(hours=NotificationType.MANAGER.hours):
+        if latest_notification_type != NotificationType.MANAGER:
+            notify_manager(jira, issue)
+    elif delta > timedelta(hours=NotificationType.TEAM_LEAD.hours):
+        if latest_notification_type != NotificationType.TEAM_LEAD:
+            notify_team_lead(jira, issue)
+    elif delta > timedelta(hours=NotificationType.QA_CONTACT.hours):
+        if latest_notification_type != NotificationType.QA_CONTACT:
+            notify_qa_contact(jira, issue)
+
+def get_on_qa_issues(jira: JIRA) -> list[Issue]:
+    ON_QA_ISSUES_FILTER = "project = OCPBUGS AND issuetype in (Bug, Vulnerability) AND status = ON_QA AND affectedVersion in (4.12.z, 4.13.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
+
+    start_at = 0
+    max_results = 100
+    on_qa_issues = []
+
+    while True:
+        issues = jira.search_issues(
+            ON_QA_ISSUES_FILTER, startAt=start_at, maxResults=max_results, expand="changelog"
+        )
+        if not issues:
+            break
+        on_qa_issues.extend(issues)
+        start_at += len(issues)
+
+    return on_qa_issues
+
+def process_on_qa_issues(jira: JIRA) -> None:
+    for issue in get_on_qa_issues(jira):
+        check_issue_and_notify_responsible_people(jira, issue)

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -18,15 +18,21 @@ class NotificationType(Enum):
     QA_CONTACT = (24, "QA Contact Action Request")
     TEAM_LEAD = (48, "Team Lead Action Request")
     MANAGER = (72, "Manager Action Request")
+    ASSIGNEE = (24, "Assignee Action Request")
 
     def __init__(self, hours: int, label: str):
         self.hours = hours
         self.label = label
 
+class Contact(Enum):
+    QA_CONTACT = "QA Contact"
+    TEAM_LEAD = "Team Lead"
+    MANAGER = "Manager"
+
 def create_notification_title(notification_type: NotificationType) -> str:
     return (
         f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}\n"
-        f"This issue has been in the ON_QA state for over {notification_type.hours} hours."
+        f"This issue has been in the ON_QA state for over {notification_type.hours} hours.\n"
     )
 
 def get_notification_type(notification_message: str) -> Optional[NotificationType]:
@@ -34,6 +40,9 @@ def get_notification_type(notification_message: str) -> Optional[NotificationTyp
         if notification_type.label in notification_message:
             return notification_type
     return None
+
+def create_jira_comment_mention(user: User) -> str:
+    return f"[~{user.name}] "
 
 def find_user_by_email(jira: JIRA, email: str) -> Optional[User]:
     for user in jira.search_users(user=email):
@@ -50,9 +59,9 @@ def get_qa_contact(issue: Issue) -> Optional[User]:
         logger.warning(f"Issue {issue.key} does not have a QA contact.")
         return None
 
-def get_manager(jira: JIRA, qa_contact: User) -> Optional[User]:
+def get_manager(jira: JIRA, user: User) -> Optional[User]:
     ldap = LdapHelper()
-    manager_email = ldap.get_manager_email(qa_contact.emailAddress)
+    manager_email = ldap.get_manager_email(user.emailAddress)
     if manager_email:
         manager = find_user_by_email(jira, manager_email)
         if manager:
@@ -60,50 +69,101 @@ def get_manager(jira: JIRA, qa_contact: User) -> Optional[User]:
         else:
             logger.warning(f"Manager {manager_email} was not found in Jira.")
     else:
-        logger.warning(f"Manager of QA contact {qa_contact.emailAddress} was not found in LDAP.")
+        logger.warning(f"Manager of {user.emailAddress} was not found in LDAP.")
     return None
 
-def create_qa_notification_text(issue: Issue)  -> str:
-    qa_contact_link = ""
-    qa_contact = get_qa_contact(issue)
-    if qa_contact:
-        qa_contact_link = f"[~{qa_contact.name}] "
+def get_assignee(issue: Issue) -> User:
+    assignee = issue.fields.assignee
+    if assignee:
+        return assignee
     else:
-        logger.warning(f"Notification text was generated without a link to the QA Contact for Jira ticket {issue.key}.")
-    return f"{create_notification_title(NotificationType.QA_CONTACT)}\n{qa_contact_link}Please verify the Jira ticket as soon as possible."
+        logger.warning(f"Issue {issue.key} does not have an Assignee.")
+        return None
+
+def create_assignee_notification(missing_contact: Contact, notified_assignees: list[User]) -> str:
+    message = ""
+    if missing_contact == Contact.QA_CONTACT:
+        message = f"The QA contact is missing."
+    elif missing_contact == Contact.TEAM_LEAD or missing_contact == Contact.MANAGER:
+        message = f"There has been no response from the QA contact and the {missing_contact.value} is not listed in Jira."
+    else:
+        raise ValueError(f"Unknown Contact value: {missing_contact}.")
+    
+    return (
+        f"{create_notification_title(NotificationType.ASSIGNEE)}"
+        f"{''.join(create_jira_comment_mention(u) for u in notified_assignees)}"
+        f"{message} Could you please help us identify someone who could review the issue?"
+    )
+
+def has_assignee_notification(issue: Issue) -> bool:
+    for comment in issue.fields.comment.comments:
+        if comment.body.startswith(create_notification_title(NotificationType.ASSIGNEE)):
+            return True
+    return False
+
+def notify_assignees(jira: JIRA, issue: Issue, missing_contact: Contact) -> None:
+    if not has_assignee_notification(issue):
+        assignee = get_assignee(issue)
+        if assignee:
+            notified_assignees = [assignee]
+            assignee_manager = get_manager(jira, assignee)
+            if assignee_manager:
+                notified_assignees.append(assignee_manager)
+            jira.add_comment(issue, create_assignee_notification(missing_contact, notified_assignees))
+        else:
+            raise Exception(f"No contact is available. Issue {issue.key} does not have assignee.")
+    else:
+        logger.warning(f"Assignees have already been notified about the missing {missing_contact.value} contact.")
+
+def create_qa_notification_text(qa_contact: User) -> str:
+    return (
+        f"{create_notification_title(NotificationType.QA_CONTACT)}"
+        f"{create_jira_comment_mention(qa_contact)}Please verify the Issue as soon as possible."
+    )
 
 def notify_qa_contact(jira: JIRA, issue: Issue) -> None:
-    jira.add_comment(issue, create_qa_notification_text(issue))
-
-def create_team_lead_notification_text(issue: Issue) -> str:
-    qa_contact_link = ""
     qa_contact = get_qa_contact(issue)
     if qa_contact:
-        qa_contact_link = f"[~{qa_contact.name}] "
+        jira.add_comment(issue, create_qa_notification_text(qa_contact))
     else:
-        logger.warning(f"Notification text was generated without a link to the QA Contact for Jira ticket {issue.key}.")
-    return f"{create_notification_title(NotificationType.TEAM_LEAD)}\n{qa_contact_link}Please verify the Jira ticket as soon as possible or arrange a reassignment with your team lead."
+        logger.warning("QA contact is missing. Assignees will be notified.")
+        notify_assignees(jira, issue, Contact.QA_CONTACT)
+
+def create_team_lead_notification_text(qa_contact: User) -> Optional[str]:
+    return (
+        f"{create_notification_title(NotificationType.TEAM_LEAD)}"
+        f"{create_jira_comment_mention(qa_contact)}Please verify the Issue as soon as possible or arrange a reassignment with your team lead."
+    )
 
 def notify_team_lead(jira: JIRA, issue: Issue) -> None:
     logger.info("Notification to the team lead is not yet implemented. Notifying the QA contact again.")
-    jira.add_comment(issue, create_team_lead_notification_text(issue))
 
-def create_manager_notification_text(jira: JIRA, issue: Issue) -> str:
     qa_contact = get_qa_contact(issue)
-    manager_link = ""
+    if qa_contact:
+        jira.add_comment(issue, create_team_lead_notification_text(qa_contact))
+    else:
+        logger.warning("QA contact is missing. Assignees will be notified.")
+        notify_assignees(jira, issue, Contact.QA_CONTACT)
+
+def create_manager_notification_text(manager: User) -> str:
+    return (
+        f"{create_notification_title(NotificationType.MANAGER)}"
+        f"{create_jira_comment_mention(manager)}Please prioritize the Issue verification or consider reassigning it to another available QA Contact."
+    )
+
+def notify_manager(jira: JIRA, issue: Issue) -> None:
+    qa_contact = get_qa_contact(issue)
     if qa_contact:
         manager = get_manager(jira, qa_contact)
         if manager:
-            manager_link = f"[~{manager.name}] "
+            jira.add_comment(issue, create_manager_notification_text(manager))
         else:
-            logger.warning(f"Notification text was generated without a link to the Manager for Jira ticket {issue.key} (Missing Manager).")
+            logger.warning("Manager was not found. Assignees will be notified.")
+            notify_assignees(jira, issue, Contact.MANAGER)
     else:
-        logger.warning(f"Notification text was generated without a link to the Manager for Jira ticket {issue.key} (Missing QA Contact).")
-    return f"{create_notification_title(NotificationType.MANAGER)}\n{manager_link}Please prioritize the Jira ticket verification or consider reassigning it to another available QA Contact."
+        logger.warning("QA contact is missing. Assignees will be notified.")
+        notify_assignees(jira, issue, Contact.QA_CONTACT)
 
-def notify_manager(jira: JIRA, issue: Issue) -> None:
-    jira.add_comment(issue, create_manager_notification_text(jira, issue))
-   
 def get_latest_on_qa_transition_datetime(issue: Issue) -> Optional[datetime]:
     latest_on_qa: datetime = None
 
@@ -157,7 +217,7 @@ def check_issue_and_notify_responsible_people(jira: JIRA, issue: Issue) -> None:
             if latest_notification_type != NotificationType.QA_CONTACT:
                 notify_qa_contact(jira, issue)
     except Exception as e:
-        logger.error(f"An error occured while processing the Jira ticket {issue.key}: {e}")
+        logger.error(f"An error occured while processing the Issue {issue.key}: {e}")
 
 def get_on_qa_issues(jira: JIRA, search_batch_size: int) -> list[Issue]:
     ON_QA_ISSUES_FILTER = "project = OCPBUGS AND issuetype in (Bug, Vulnerability) AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -56,551 +56,547 @@ class Notification:
         self.type = type
         self.text = text
 
-def create_notification_title(notification_type: NotificationType) -> str:
+class NotificationService:
     """
-    Returns a formatted notification title based on the given type.
-
-    Args:
-        notification_type (NotificationType): The type of notification.
-
-    Returns:
-        str: A string with the notification title and time information.
-    """
-
-    return (
-        f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}\n"
-        f"This issue has been in the ON_QA state for over {notification_type.hours} hours.\n"
-    )
-
-def get_notification_type(notification_message: str) -> Optional[NotificationType]:
-    """
-    Extracts the notification type from a message string.
-
-    Args:
-        notification_message (str): The message to search.
-
-    Returns:
-        Optional[NotificationType]: The matching notification type, or None if not found.
-    """
-     
-    for notification_type in NotificationType:
-        if notification_type.label in notification_message:
-            return notification_type
-    return None
-
-def create_jira_comment_mentions(users: List[User]) -> str:
-    """
-    Creates a Jira-formatted mention string for a list of users.
-
-    Args:
-        users (List[User]): List of users to mention.
-
-    Returns:
-        str: A string with Jira mentions (e.g., "[~user1] [~user2]").
-    """
-
-    jira_comment_mentions = ""
-    for u in users:
-        jira_comment_mentions += f"[~{u.name}] "
-    return jira_comment_mentions
-
-def process_notification(jira: JIRA, notification: Notification, dry_run: bool) -> None:
-    """
-    Sends or logs a notification as a JIRA comment.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        notification (Notification): The notification to process.
-        dry_run (bool): If True, logs the action without sending.
-    """
-
-    log_message = f"- {notification.type.label} - notification to Issue - {notification.issue.key}: {notification.text}"
-    if not dry_run:
-        logger.info(f"Sending {log_message}")
-        jira.add_comment(notification.issue, notification.text)
-    else:
-        logger.info(f"Skipping sending {log_message}")
-
-def find_user_by_email(jira: JIRA, email: str) -> Optional[User]:
-    """
-    Searches for a JIRA user by email address.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        email (str): Email address to search for.
-
-    Returns:
-        Optional[User]: The matched user if found, otherwise None.
-    """
-
-    for user in jira.search_users(user=email):
-        if user.emailAddress == email:
-            return user
-    logger.warning(f"User was not found for email {email}.")
-    return None
-
-def get_qa_contact(issue: Issue) -> Optional[User]:
-    """
-    Retrieves the QA contact user from an issue.
-
-    Args:
-        issue (Issue): The JIRA issue to inspect.
-
-    Returns:
-        Optional[User]: The QA contact user if set, otherwise None.
-    """
-
-    qa_contact = issue.fields.customfield_12315948
-    if qa_contact:
-        return qa_contact
-    else:
-        logger.warning(f"Issue {issue.key} does not have a QA contact.")
-        return None
-
-def get_manager(jira: JIRA, user: User) -> Optional[User]:
-    """
-    Retrieves the manager of a given user via LDAP and matches them in JIRA.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        user (User): The user whose manager is to be found.
-
-    Returns:
-        Optional[User]: The manager user if found, otherwise None.
-    """
-
-    ldap = LdapHelper()
-    manager_email = ldap.get_manager_email(user.emailAddress)
-    if manager_email:
-        manager = find_user_by_email(jira, manager_email)
-        if manager:
-            return manager
-        else:
-            logger.warning(f"Manager {manager_email} was not found in Jira.")
-    else:
-        logger.warning(f"Manager of {user.emailAddress} was not found in LDAP.")
-    return None
-
-def get_assignee(issue: Issue) -> Optional[User]:
-    """
-    Retrieves the assignee user from an issue.
-
-    Args:
-        issue (Issue): The JIRA issue to inspect.
-
-    Returns:
-        Optional[User]: The assignee user if set, otherwise None.
-    """
-
-    assignee = issue.fields.assignee
-    if assignee:
-        return assignee
-    else:
-        logger.warning(f"Issue {issue.key} does not have an Assignee.")
-        return None
-
-def create_assignee_notification_text(missing_contact: Contact, notified_assignees: list[User]) -> str:
-    """
-    Creates a notification text for assignees when a contact is missing.
-
-    Args:
-        missing_contact (Contact): The type of missing contact.
-        notified_assignees (list[User]): List of users to be notified.
-
-    Returns:
-        str: The complete notification message text.
-    """
-
-    message = ""
-    if missing_contact == Contact.QA_CONTACT:
-        message = f"The QA contact is missing."
-    elif missing_contact == Contact.TEAM_LEAD or missing_contact == Contact.MANAGER:
-        message = f"There has been no response from the QA contact and the {missing_contact.value} is not listed in Jira."
-    else:
-        raise ValueError(f"Unknown Contact value: {missing_contact}.")
+    Represents a service for sending notifications via the Jira API.
     
-    return (
-        f"{create_notification_title(NotificationType.ASSIGNEE)}"
-        f"{create_jira_comment_mentions(notified_assignees)}"
-        f"{message} Could you please help us identify someone who could verify the issue?"
-    )
-
-def has_assignee_notification(issue: Issue) -> bool:
-    """
-    Checks if the issue already contains an assignee notification comment.
-
-    Args:
-        issue (Issue): The JIRA issue to inspect.
-
-    Returns:
-        bool: True if an assignee notification comment is found, False otherwise.
-    """
-
-    for comment in issue.fields.comment.comments:
-        if comment.body.startswith(create_notification_title(NotificationType.ASSIGNEE)):
-            return True
-    return False
-
-def notify_assignees(jira: JIRA, issue: Issue, missing_contact: Contact, dry_run: bool) -> Optional[Notification]:
-    """
-    Notifies assignees about a missing contact on an issue, if not already notified.
-
-    Args:
+    Attributes:
         jira (JIRA): JIRA API client instance.
-        issue (Issue): The issue related to the notification.
-        missing_contact (Contact): The type of missing contact triggering the notification.
-        dry_run (bool): If True, simulate the notification without sending.
-
-    Returns:
-        Optional[Notification]: The created notification if sent, otherwise None.
-
-    Raises:
-        Exception: If no assignee is available on the issue.
+        dry_run (bool): If True, logs the action without sending comments to Jira.
     """
+    
+    def __init__(self, jira, dry_run=False):
+        self.jira = jira
+        self.dry_run = dry_run
 
-    if not has_assignee_notification(issue):
-        assignee = get_assignee(issue)
+    def create_notification_title(self, notification_type: NotificationType) -> str:
+        """
+        Returns a formatted notification title based on the given type.
+
+        Args:
+            notification_type (NotificationType): The type of notification.
+
+        Returns:
+            str: A string with the notification title and time information.
+        """
+
+        return (
+            f"{ERT_NOTIFICATION_PREFIX} - {notification_type.label}\n"
+            f"This issue has been in the ON_QA state for over {notification_type.hours} hours.\n"
+        )
+
+    def get_notification_type(self, notification_message: str) -> Optional[NotificationType]:
+        """
+        Extracts the notification type from a message string.
+
+        Args:
+            notification_message (str): The message to search.
+
+        Returns:
+            Optional[NotificationType]: The matching notification type, or None if not found.
+        """
+        
+        for notification_type in NotificationType:
+            if notification_type.label in notification_message:
+                return notification_type
+        return None
+
+    def create_jira_comment_mentions(self, users: List[User]) -> str:
+        """
+        Creates a Jira-formatted mention string for a list of users.
+
+        Args:
+            users (List[User]): List of users to mention.
+
+        Returns:
+            str: A string with Jira mentions (e.g., "[~user1] [~user2]").
+        """
+
+        jira_comment_mentions = ""
+        for u in users:
+            jira_comment_mentions += f"[~{u.name}] "
+        return jira_comment_mentions
+
+    def process_notification(self, notification: Notification) -> None:
+        """
+        Sends or logs a notification as a JIRA comment.
+
+        Args:
+            notification (Notification): The notification to process.
+        """
+
+        log_message = f"- {notification.type.label} - notification to Issue - {notification.issue.key}: {notification.text}"
+        if not self.dry_run:
+            logger.info(f"Sending {log_message}")
+            self.jira.add_comment(notification.issue, notification.text)
+        else:
+            logger.info(f"Skipping sending {log_message}")
+
+    def find_user_by_email(self, email: str) -> Optional[User]:
+        """
+        Searches for a JIRA user by email address.
+
+        Args:
+            email (str): Email address to search for.
+
+        Returns:
+            Optional[User]: The matched user if found, otherwise None.
+        """
+
+        for user in self.jira.search_users(user=email):
+            if user.emailAddress == email:
+                return user
+        logger.warning(f"User was not found for email {email}.")
+        return None
+
+    def get_qa_contact(self, issue: Issue) -> Optional[User]:
+        """
+        Retrieves the QA contact user from an issue.
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+
+        Returns:
+            Optional[User]: The QA contact user if set, otherwise None.
+        """
+
+        qa_contact = issue.fields.customfield_12315948
+        if qa_contact:
+            return qa_contact
+        else:
+            logger.warning(f"Issue {issue.key} does not have a QA contact.")
+            return None
+
+    def get_manager(self, user: User) -> Optional[User]:
+        """
+        Retrieves the manager of a given user via LDAP and matches them in JIRA.
+
+        Args:
+            user (User): The user whose manager is to be found.
+
+        Returns:
+            Optional[User]: The manager user if found, otherwise None.
+        """
+
+        ldap = LdapHelper()
+        manager_email = ldap.get_manager_email(user.emailAddress)
+        if manager_email:
+            manager = self.find_user_by_email(manager_email)
+            if manager:
+                return manager
+            else:
+                logger.warning(f"Manager {manager_email} was not found in Jira.")
+        else:
+            logger.warning(f"Manager of {user.emailAddress} was not found in LDAP.")
+        return None
+
+    def get_assignee(self, issue: Issue) -> Optional[User]:
+        """
+        Retrieves the assignee user from an issue.
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+
+        Returns:
+            Optional[User]: The assignee user if set, otherwise None.
+        """
+
+        assignee = issue.fields.assignee
         if assignee:
-            notified_assignees = [assignee]
-            assignee_manager = get_manager(jira, assignee)
-            if assignee_manager:
-                notified_assignees.append(assignee_manager)
-            assignee_notification = Notification(
-                issue, 
-                NotificationType.ASSIGNEE, 
-                create_assignee_notification_text(missing_contact, notified_assignees)
-            )
-            process_notification(jira, assignee_notification, dry_run)
-            return assignee_notification
+            return assignee
         else:
-            raise Exception(f"No contact is available. Issue {issue.key} does not have assignee.")
-    else:
-        logger.warning(f"Assignees have already been notified about the missing {missing_contact.value} contact.")
-    return None
+            logger.warning(f"Issue {issue.key} does not have an Assignee.")
+            return None
 
-def create_qa_notification_text(qa_contact: User) -> str:
-    """
-    Creates a notification text for the QA contact to verify the issue.
+    def create_assignee_notification_text(self, missing_contact: Contact, notified_assignees: list[User]) -> str:
+        """
+        Creates a notification text for assignees when a contact is missing.
 
-    Args:
-        qa_contact (User): The QA contact user.
+        Args:
+            missing_contact (Contact): The type of missing contact.
+            notified_assignees (list[User]): List of users to be notified.
 
-    Returns:
-        str: The complete notification message text.
-    """
+        Returns:
+            str: The complete notification message text.
+        """
 
-    return (
-        f"{create_notification_title(NotificationType.QA_CONTACT)}"
-        f"{create_jira_comment_mentions([qa_contact])}Please verify the Issue as soon as possible."
-    )
-
-def notify_qa_contact(jira: JIRA, issue: Issue, dry_run: bool) -> Optional[Notification]:
-    """
-    Notifies the QA contact of the issue, or notifies assignees if QA contact is missing.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        issue (Issue): The issue to notify about.
-        dry_run (bool): If True, simulate notification without sending.
-
-    Returns:
-        Optional[Notification]: The created notification if sent, otherwise None.
-    """
-
-    qa_contact = get_qa_contact(issue)
-    if qa_contact:
-        qa_notification = Notification(
-            issue,
-            NotificationType.QA_CONTACT,
-            create_qa_notification_text(qa_contact)
-        )
-        process_notification(jira, qa_notification, dry_run)
-        return qa_notification
-    else:
-        logger.warning("QA contact is missing. Assignees will be notified.")
-        return notify_assignees(jira, issue, Contact.QA_CONTACT, dry_run)
-
-# FIXME OCPERT-139 Improve Jira notificator by notifying team leads instead QA contacts
-def create_team_lead_notification_text(qa_contact: User) -> Optional[str]:
-    """
-    Creates a notification text for the QA contact to verify the issue or arrange a reassignment with their team lead.
-
-    Args:
-        qa_contact (User): The QA contact user.
-
-    Returns:
-        str: The complete notification message text.
-    """
-
-    return (
-        f"{create_notification_title(NotificationType.TEAM_LEAD)}"
-        f"{create_jira_comment_mentions([qa_contact])}Please verify the Issue as soon as possible or arrange a reassignment with your team lead."
-    )
-
-def notify_team_lead(jira: JIRA, issue: Issue, dry_run: bool) -> Optional[Notification]:
-    """
-    Notifies the team lead via the QA contact, or notifies assignees if QA contact is missing.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        issue (Issue): The issue to notify about.
-        dry_run (bool): If True, simulate notification without sending.
-
-    Returns:
-        Optional[Notification]: The created notification if sent, otherwise None.
-    """
-
-    logger.info("Notification to the team lead is not yet implemented. Notifying the QA contact again.")
-
-    qa_contact = get_qa_contact(issue)
-    if qa_contact:
-        team_lead_notification = Notification(
-            issue,
-            NotificationType.TEAM_LEAD,
-            create_team_lead_notification_text(qa_contact)
-        )
-        process_notification(jira, team_lead_notification, dry_run)
-        return team_lead_notification
-    else:
-        logger.warning("QA contact is missing. Assignees will be notified.")
-        return notify_assignees(jira, issue, Contact.QA_CONTACT, dry_run)
-
-def create_manager_notification_text(manager: User) -> str:
-    """
-    Creates a notification text for the manager to prioritize or reassign the issue.
-
-    Args:
-        manager (User): The manager user to notify.
-
-    Returns:
-        str: The complete notification message text.
-    """
-
-    return (
-        f"{create_notification_title(NotificationType.MANAGER)}"
-        f"{create_jira_comment_mentions([manager])}Please prioritize the Issue verification or consider reassigning it to another available QA Contact."
-    )
-
-def notify_manager(jira: JIRA, issue: Issue, dry_run: bool) -> Optional[Notification]:
-    """
-    Notifies the manager, or notifies assignees if needed.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        issue (Issue): The issue to notify about.
-        dry_run (bool): If True, simulate notification without sending.
-
-    Returns:
-        Optional[Notification]: The created notification if sent, otherwise None.
-    """
-
-    qa_contact = get_qa_contact(issue)
-    if qa_contact:
-        manager = get_manager(jira, qa_contact)
-        if manager:
-            manager_notification = Notification(
-                issue,
-                NotificationType.MANAGER,
-                create_manager_notification_text(manager)
-            )
-            process_notification(jira, manager_notification, dry_run)
-            return manager_notification
+        message = ""
+        if missing_contact == Contact.QA_CONTACT:
+            message = f"The QA contact is missing."
+        elif missing_contact == Contact.TEAM_LEAD or missing_contact == Contact.MANAGER:
+            message = f"There has been no response from the QA contact and the {missing_contact.value} is not listed in Jira."
         else:
-            logger.warning("Manager was not found. Assignees will be notified.")
-            return notify_assignees(jira, issue, Contact.MANAGER, dry_run)
-    else:
-        logger.warning("QA contact is missing. Assignees will be notified.")
-        return notify_assignees(jira, issue, Contact.QA_CONTACT, dry_run)
+            raise ValueError(f"Unknown Contact value: {missing_contact}.")
+        
+        return (
+            f"{self.create_notification_title(NotificationType.ASSIGNEE)}"
+            f"{self.create_jira_comment_mentions(notified_assignees)}"
+            f"{message} Could you please help us identify someone who could verify the issue?"
+        )
 
-def get_latest_on_qa_transition_datetime(issue: Issue) -> Optional[datetime]:
-    """
-    Returns the most recent datetime when the issue transitioned to ON_QA status.
+    def has_assignee_notification(self, issue: Issue) -> bool:
+        """
+        Checks if the issue already contains an assignee notification comment.
 
-    Args:
-        issue (Issue): The JIRA issue to inspect.
+        Args:
+            issue (Issue): The JIRA issue to inspect.
 
-    Returns:
-        Optional[datetime]: The latest ON_QA transition timestamp, or None if not found.
-    """
+        Returns:
+            bool: True if an assignee notification comment is found, False otherwise.
+        """
 
-    latest_on_qa: datetime = None
-
-    for history in issue.changelog.histories:
-        for item in history.items:
-            if item.field == "status" and item.toString == "ON_QA":
-                transition_time = parser.parse(history.created)
-                if not latest_on_qa or transition_time > latest_on_qa:
-                    latest_on_qa = transition_time
-
-    return latest_on_qa
-
-def get_latest_notification_dates_after_on_qa_transition(issue: Issue, on_qa_transition: datetime) -> Dict[NotificationType, Optional[datetime]]:
-    """
-    Returns the latest notification dates for each type after the ON_QA transition.
-
-    Args:
-        issue (Issue): The JIRA issue to inspect.
-        on_qa_transition (datetime): The datetime when the issue transitioned to ON_QA.
-
-    Returns:
-        Dict[NotificationType, Optional[datetime]]: A mapping of notification types to
-        their latest comment creation datetimes after the ON_QA transition.
-    """
-
-    notification_types_with_latest_date: Dict[NotificationType, Optional[datetime]] = {}
-
-    for comment in issue.fields.comment.comments:
-        if not comment.body.startswith(ERT_NOTIFICATION_PREFIX):
-            continue
-
-        created_datetime = parser.parse(comment.created)
-        if created_datetime < on_qa_transition:
-            continue
-
-        notification_type = get_notification_type(comment.body)
-        notification_datetime = notification_types_with_latest_date.get(notification_type)
-
-        if not notification_datetime or created_datetime > notification_datetime:
-            notification_types_with_latest_date[notification_type] = created_datetime
-
-    return notification_types_with_latest_date
-
-def is_more_than_24_weekday_hours(from_date: datetime, now: Optional[datetime] = None) -> bool:
-    """
-    Checks if more than 24 weekday hours have passed since the given datetime.
-
-    Args:
-        from_date (datetime): The starting datetime.
-        now (Optional[datetime]): Current datetime used for comparison (for testing; defaults to current UTC time).
-
-    Returns:
-        bool: True if more than 24 weekday hours have passed, otherwise False.
-    """
-
-    if now is None:
-        now = datetime.now(timezone.utc)
-
-    if from_date >= now:
+        for comment in issue.fields.comment.comments:
+            if comment.body.startswith(self.create_notification_title(NotificationType.ASSIGNEE)):
+                return True
         return False
 
-    total_diff = now - from_date
+    def notify_assignees(self, issue: Issue, missing_contact: Contact) -> Optional[Notification]:
+        """
+        Notifies assignees about a missing contact on an issue, if not already notified.
 
-    if total_diff > timedelta(days=3):
-        return True
+        Args:
+            issue (Issue): The issue related to the notification.
+            missing_contact (Contact): The type of missing contact triggering the notification.
 
-    current = from_date
-    valid_hours = 0
-    while current < now:
-        if current.weekday() < 5:  # Monday to Friday
-            valid_hours += 1
-        current += timedelta(hours=1)
+        Returns:
+            Optional[Notification]: The created notification if sent, otherwise None.
 
-    return valid_hours > 24
+        Raises:
+            Exception: If no assignee is available on the issue.
+        """
 
-def check_issue_and_notify_responsible_people(jira: JIRA, issue: Issue, dry_run: bool) -> None:
-    """
-    Checks the ON_QA transition and sends notifications based on elapsed time and notification history.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        issue (Issue): The issue to evaluate and notify about.
-        dry_run (bool): If True, simulate notifications without sending them.
-    """
-
-    try:
-        on_qa_datetime = get_latest_on_qa_transition_datetime(issue)
-        if not on_qa_datetime:
-            logger.error(f"Issue {issue.key} does not have ON_QA transition date")
-            return
-        
-        notification_dates = get_latest_notification_dates_after_on_qa_transition(issue, on_qa_datetime)
-
-        if not notification_dates.get(NotificationType.QA_CONTACT):
-            if is_more_than_24_weekday_hours(on_qa_datetime):
-                logger.info("Notifying QA Contact")
-                notify_qa_contact(jira, issue, dry_run)
+        if not self.has_assignee_notification(issue):
+            assignee = self.get_assignee(issue)
+            if assignee:
+                notified_assignees = [assignee]
+                assignee_manager = self.get_manager(assignee)
+                if assignee_manager:
+                    notified_assignees.append(assignee_manager)
+                assignee_notification = Notification(
+                    issue, 
+                    NotificationType.ASSIGNEE, 
+                    self.create_assignee_notification_text(missing_contact, notified_assignees)
+                )
+                self.process_notification(assignee_notification)
+                return assignee_notification
             else:
-                logger.info("Skipping notifying QA Contact - less than 24 hour from transition to ON_QA.")
-        elif not notification_dates.get(NotificationType.TEAM_LEAD): 
-            if is_more_than_24_weekday_hours(notification_dates.get(NotificationType.QA_CONTACT)):
-                logger.info("Notifying Team Lead")
-                notify_team_lead(jira, issue, dry_run)
-            else:
-                logger.info("Skipping notifying Team Lead - less than 24 hour from QA Contact notification.")
-        elif not notification_dates.get(NotificationType.MANAGER):
-            if is_more_than_24_weekday_hours(notification_dates.get(NotificationType.TEAM_LEAD)):
-                logger.info("Notifying Manager")
-                notify_manager(jira, issue, dry_run)
-            else:
-                logger.info("Skipping notifying Manager - less than 24 hour from Team Lead notification.")
+                raise Exception(f"No contact is available. Issue {issue.key} does not have assignee.")
         else:
-            logger.warning("All contacts have been notified.")
+            logger.warning(f"Assignees have already been notified about the missing {missing_contact.value} contact.")
+        return None
 
-    except Exception as e:
-        logger.error(f"An error occured while processing the Issue {issue.key}: {e}")
+    def create_qa_notification_text(self, qa_contact: User) -> str:
+        """
+        Creates a notification text for the QA contact to verify the issue.
 
-def get_on_qa_filter(from_date: Optional[datetime] = None) -> str:
-    """
-    Constructs a JIRA JQL filter string for ON_QA issues optionally filtered by a date.
+        Args:
+            qa_contact (User): The QA contact user.
 
-    Args:
-        from_date (Optional[datetime]): If provided, filters issues that transitioned to ON_QA after this date.
+        Returns:
+            str: The complete notification message text.
+        """
 
-    Returns:
-        str: The JQL filter string.
-    """
-
-    base_filter = (
-        "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
-        "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
-    )
-
-    date_suffix = f" AND status changed to ON_QA after {from_date.strftime('%Y-%m-%d')}" if from_date else ""
-
-    return base_filter + date_suffix
-
-def get_on_qa_issues(jira: JIRA, search_batch_size: int, from_date: Optional[datetime]) -> List[Issue]:
-    """
-    Retrieves ON_QA issues from JIRA in batches, optionally filtered by a date.
-
-    Args:
-        jira (JIRA): JIRA API client instance.
-        search_batch_size (int): Number of issues to fetch per batch.
-        from_date (Optional[datetime]): If provided, fetches issues transitioned to ON_QA after this date.
-
-    Returns:
-        List[Issue]: A list of JIRA issues matching the ON_QA criteria.
-    """
-
-    start_at = 0
-    on_qa_issues = []
-
-    while True:
-        # FIXME: OCPERT-135 Find a solution to access Jira tickets with limited permissions
-        issues = jira.search_issues(
-            get_on_qa_filter(from_date), startAt=start_at, maxResults=search_batch_size, expand="changelog"
+        return (
+            f"{self.create_notification_title(NotificationType.QA_CONTACT)}"
+            f"{self.create_jira_comment_mentions([qa_contact])}Please verify the Issue as soon as possible."
         )
-        if not issues:
-            break
-        on_qa_issues.extend(issues)
-        start_at += len(issues)
 
-    return on_qa_issues
+    def notify_qa_contact(self, issue: Issue) -> Optional[Notification]:
+        """
+        Notifies the QA contact of the issue, or notifies assignees if QA contact is missing.
 
-def process_on_qa_issues(jira: JIRA, search_batch_size: int, dry_run: bool, from_date: Optional[datetime]) -> None:
-    """
-    Processes ON_QA issues by checking and notifying responsible people.
+        Args:
+            issue (Issue): The issue to notify about.
 
-    Args:
-        jira (JIRA): JIRA API client instance.
-        search_batch_size (int): Number of issues to fetch per batch.
-        dry_run (bool): If True, simulate notifications without sending.
-        from_date (Optional[datetime]): If provided, process issues transitioned to ON_QA after this date.
-    """
+        Returns:
+            Optional[Notification]: The created notification if sent, otherwise None.
+        """
 
-    for issue in get_on_qa_issues(jira, search_batch_size, from_date):
-        logger.info(f"Processing {issue.key}")
-        check_issue_and_notify_responsible_people(jira, issue, dry_run)
+        qa_contact = self.get_qa_contact(issue)
+        if qa_contact:
+            qa_notification = Notification(
+                issue,
+                NotificationType.QA_CONTACT,
+                self.create_qa_notification_text(qa_contact)
+            )
+            self.process_notification(qa_notification)
+            return qa_notification
+        else:
+            logger.warning("QA contact is missing. Assignees will be notified.")
+            return self.notify_assignees(issue, Contact.QA_CONTACT)
+
+    # FIXME OCPERT-139 Improve Jira notificator by notifying team leads instead QA contacts
+    def create_team_lead_notification_text(self, qa_contact: User) -> Optional[str]:
+        """
+        Creates a notification text for the QA contact to verify the issue or arrange a reassignment with their team lead.
+
+        Args:
+            qa_contact (User): The QA contact user.
+
+        Returns:
+            str: The complete notification message text.
+        """
+
+        return (
+            f"{self.create_notification_title(NotificationType.TEAM_LEAD)}"
+            f"{self.create_jira_comment_mentions([qa_contact])}Please verify the Issue as soon as possible or arrange a reassignment with your team lead."
+        )
+
+    def notify_team_lead(self, issue: Issue) -> Optional[Notification]:
+        """
+        Notifies the team lead via the QA contact, or notifies assignees if QA contact is missing.
+
+        Args:
+            issue (Issue): The issue to notify about.
+
+        Returns:
+            Optional[Notification]: The created notification if sent, otherwise None.
+        """
+
+        logger.info("Notification to the team lead is not yet implemented. Notifying the QA contact again.")
+
+        qa_contact = self.get_qa_contact(issue)
+        if qa_contact:
+            team_lead_notification = Notification(
+                issue,
+                NotificationType.TEAM_LEAD,
+                self.create_team_lead_notification_text(qa_contact)
+            )
+            self.process_notification(team_lead_notification)
+            return team_lead_notification
+        else:
+            logger.warning("QA contact is missing. Assignees will be notified.")
+            return self.notify_assignees(issue, Contact.QA_CONTACT)
+
+    def create_manager_notification_text(self, manager: User) -> str:
+        """
+        Creates a notification text for the manager to prioritize or reassign the issue.
+
+        Args:
+            manager (User): The manager user to notify.
+
+        Returns:
+            str: The complete notification message text.
+        """
+
+        return (
+            f"{self.create_notification_title(NotificationType.MANAGER)}"
+            f"{self.create_jira_comment_mentions([manager])}Please prioritize the Issue verification or consider reassigning it to another available QA Contact."
+        )
+
+    def notify_manager(self, issue: Issue) -> Optional[Notification]:
+        """
+        Notifies the manager, or notifies assignees if needed.
+
+        Args:
+            issue (Issue): The issue to notify about.
+
+        Returns:
+            Optional[Notification]: The created notification if sent, otherwise None.
+        """
+
+        qa_contact = self.get_qa_contact(issue)
+        if qa_contact:
+            manager = self.get_manager(qa_contact)
+            if manager:
+                manager_notification = Notification(
+                    issue,
+                    NotificationType.MANAGER,
+                    self.create_manager_notification_text(manager)
+                )
+                self.process_notification(manager_notification)
+                return manager_notification
+            else:
+                logger.warning("Manager was not found. Assignees will be notified.")
+                return self.notify_assignees(issue, Contact.MANAGER)
+        else:
+            logger.warning("QA contact is missing. Assignees will be notified.")
+            return self.notify_assignees(issue, Contact.QA_CONTACT)
+
+    def get_latest_on_qa_transition_datetime(self, issue: Issue) -> Optional[datetime]:
+        """
+        Returns the most recent datetime when the issue transitioned to ON_QA status.
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+
+        Returns:
+            Optional[datetime]: The latest ON_QA transition timestamp, or None if not found.
+        """
+
+        latest_on_qa: datetime = None
+
+        for history in issue.changelog.histories:
+            for item in history.items:
+                if item.field == "status" and item.toString == "ON_QA":
+                    transition_time = parser.parse(history.created)
+                    if not latest_on_qa or transition_time > latest_on_qa:
+                        latest_on_qa = transition_time
+
+        return latest_on_qa
+
+    def get_latest_notification_dates_after_on_qa_transition(self, issue: Issue, on_qa_transition: datetime) -> Dict[NotificationType, Optional[datetime]]:
+        """
+        Returns the latest notification dates for each type after the ON_QA transition.
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+            on_qa_transition (datetime): The datetime when the issue transitioned to ON_QA.
+
+        Returns:
+            Dict[NotificationType, Optional[datetime]]: A mapping of notification types to
+            their latest comment creation datetimes after the ON_QA transition.
+        """
+
+        notification_types_with_latest_date: Dict[NotificationType, Optional[datetime]] = {}
+
+        for comment in issue.fields.comment.comments:
+            if not comment.body.startswith(ERT_NOTIFICATION_PREFIX):
+                continue
+
+            created_datetime = parser.parse(comment.created)
+            if created_datetime < on_qa_transition:
+                continue
+
+            notification_type = self.get_notification_type(comment.body)
+            notification_datetime = notification_types_with_latest_date.get(notification_type)
+
+            if not notification_datetime or created_datetime > notification_datetime:
+                notification_types_with_latest_date[notification_type] = created_datetime
+
+        return notification_types_with_latest_date
+
+    def is_more_than_24_weekday_hours(self, from_date: datetime, now: Optional[datetime] = None) -> bool:
+        """
+        Checks if more than 24 weekday hours have passed since the given datetime.
+
+        Args:
+            from_date (datetime): The starting datetime.
+            now (Optional[datetime]): Current datetime used for comparison (for testing; defaults to current UTC time).
+
+        Returns:
+            bool: True if more than 24 weekday hours have passed, otherwise False.
+        """
+
+        if now is None:
+            now = datetime.now(timezone.utc)
+
+        if from_date >= now:
+            return False
+
+        total_diff = now - from_date
+
+        if total_diff > timedelta(days=3):
+            return True
+
+        current = from_date
+        valid_hours = 0
+        while current < now:
+            if current.weekday() < 5:  # Monday to Friday
+                valid_hours += 1
+            current += timedelta(hours=1)
+
+        return valid_hours > 24
+
+    def check_issue_and_notify_responsible_people(self, issue: Issue) -> None:
+        """
+        Checks the ON_QA transition and sends notifications based on elapsed time and notification history.
+
+        Args:
+            issue (Issue): The issue to evaluate and notify about.
+        """
+
+        try:
+            on_qa_datetime = self.get_latest_on_qa_transition_datetime(issue)
+            if not on_qa_datetime:
+                logger.error(f"Issue {issue.key} does not have ON_QA transition date")
+                return
+            
+            notification_dates = self.get_latest_notification_dates_after_on_qa_transition(issue, on_qa_datetime)
+
+            if not notification_dates.get(NotificationType.QA_CONTACT):
+                if self.is_more_than_24_weekday_hours(on_qa_datetime):
+                    logger.info("Notifying QA Contact")
+                    self.notify_qa_contact(issue)
+                else:
+                    logger.info("Skipping notifying QA Contact - less than 24 hour from transition to ON_QA.")
+            elif not notification_dates.get(NotificationType.TEAM_LEAD): 
+                if self.is_more_than_24_weekday_hours(notification_dates.get(NotificationType.QA_CONTACT)):
+                    logger.info("Notifying Team Lead")
+                    self.notify_team_lead(issue)
+                else:
+                    logger.info("Skipping notifying Team Lead - less than 24 hour from QA Contact notification.")
+            elif not notification_dates.get(NotificationType.MANAGER):
+                if self.is_more_than_24_weekday_hours(notification_dates.get(NotificationType.TEAM_LEAD)):
+                    logger.info("Notifying Manager")
+                    self.notify_manager(issue)
+                else:
+                    logger.info("Skipping notifying Manager - less than 24 hour from Team Lead notification.")
+            else:
+                logger.warning("All contacts have been notified.")
+
+        except Exception as e:
+            logger.error(f"An error occured while processing the Issue {issue.key}: {e}")
+
+    def get_on_qa_filter(self, from_date: Optional[datetime] = None) -> str:
+        """
+        Constructs a JIRA JQL filter string for ON_QA issues optionally filtered by a date.
+
+        Args:
+            from_date (Optional[datetime]): If provided, filters issues that transitioned to ON_QA after this date.
+
+        Returns:
+            str: The JQL filter string.
+        """
+
+        base_filter = (
+            "project = OCPBUGS AND issuetype in (Bug, Vulnerability) "
+            "AND status = ON_QA AND 'Target Version' in (4.12.z, 4.13.z, 4.14.z, 4.15.z, 4.16.z, 4.17.z, 4.18.z, 4.19.z)"
+        )
+
+        date_suffix = f" AND status changed to ON_QA after {from_date.strftime('%Y-%m-%d')}" if from_date else ""
+
+        return base_filter + date_suffix
+
+    def get_on_qa_issues(self, search_batch_size: int, from_date: Optional[datetime]) -> List[Issue]:
+        """
+        Retrieves ON_QA issues from JIRA in batches, optionally filtered by a date.
+
+        Args:
+            search_batch_size (int): Number of issues to fetch per batch.
+            from_date (Optional[datetime]): If provided, fetches issues transitioned to ON_QA after this date.
+
+        Returns:
+            List[Issue]: A list of JIRA issues matching the ON_QA criteria.
+        """
+
+        start_at = 0
+        on_qa_issues = []
+
+        while True:
+            # FIXME: OCPERT-135 Find a solution to access Jira tickets with limited permissions
+            issues = self.jira.search_issues(
+                self.get_on_qa_filter(from_date), startAt=start_at, maxResults=search_batch_size, expand="changelog"
+            )
+            if not issues:
+                break
+            on_qa_issues.extend(issues)
+            start_at += len(issues)
+
+        return on_qa_issues
+
+    def process_on_qa_issues(self, search_batch_size: int, from_date: Optional[datetime]) -> None:
+        """
+        Processes ON_QA issues by checking and notifying responsible people.
+
+        Args:
+            search_batch_size (int): Number of issues to fetch per batch.
+            from_date (Optional[datetime]): If provided, process issues transitioned to ON_QA after this date.
+        """
+
+        for issue in self.get_on_qa_issues(search_batch_size, from_date):
+            logger.info(f"Processing {issue.key}")
+            self.check_issue_and_notify_responsible_people(issue)
 
 @click.command()
 @click.option("--search-batch-size", default=100, type=int, help="Maximum number of results to retrieve in each search iteration or batch.")
@@ -621,7 +617,9 @@ def main(search_batch_size: int, dry_run: bool, from_date: Optional[datetime]) -
 
     jira_token = os.environ.get("JIRA_TOKEN")
     jira = JIRA(server="https://issues.redhat.com", token_auth=jira_token)
-    process_on_qa_issues(jira, search_batch_size, dry_run, from_date)
+
+    ns = NotificationService(jira, dry_run)
+    ns.process_on_qa_issues(search_batch_size, from_date)
 
 if __name__ == "__main__":
     main()

--- a/tools/jira_notificator.py
+++ b/tools/jira_notificator.py
@@ -222,7 +222,7 @@ def create_assignee_notification_text(missing_contact: Contact, notified_assigne
     return (
         f"{create_notification_title(NotificationType.ASSIGNEE)}"
         f"{create_jira_comment_mentions(notified_assignees)}"
-        f"{message} Could you please help us identify someone who could review the issue?"
+        f"{message} Could you please help us identify someone who could verify the issue?"
     )
 
 def has_assignee_notification(issue: Issue) -> bool:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPERT-98

This PR introduces a JIRA notification tool that monitors issues in the ON_QA state and sends escalation notifications to the appropriate stakeholders in a defined sequence.

The notification flow is as follows:

1. **QA Contact** – If an issue remains in ON_QA for more than 24 weekday hours, a notification is sent to the assigned QA contact requesting verification.

2. **Second Reminder (QA Contact / Team Lead)** – If the issue is still unresolved after another 24 weekday hours, a second notification is sent to the QA contact (planned: escalation to the Team Lead), requesting verification or coordination with their team lead to reassign the issue.
 
3. **Manager** – After another 24 weekday hours without resolution, a notification is sent to the QA contact’s manager, asking them to prioritize the verification or reassign the issue to an available QA contact.

If the QA contact or their manager is missing in JIRA, the system notifies the assignee and their manager, asking them to identify someone to verify the issue.