### PR TITLE
OCPERT-136 Add container image health check for shipment components

### DIFF
--- a/oar/cli/cmd_image_consistency_check.py
+++ b/oar/cli/cmd_image_consistency_check.py
@@ -90,8 +90,7 @@ def image_consistency_check(ctx, build_number, for_nightly):
 
             if job_status == JENKINS_JOB_STATUS_SUCCESS:
                 health_data = sd.check_component_image_health()
-                unhealthy_count = health_data[1] # unhealthy_count is index 1
-                if unhealthy_count == 0:  
+                if health_data.unhealthy_count == 0:
                     report.update_task_status(LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_PASS)
                 else:
                     sd.add_image_health_summary_comment(health_data)

--- a/oar/cli/cmd_image_consistency_check.py
+++ b/oar/cli/cmd_image_consistency_check.py
@@ -8,6 +8,7 @@ from oar.core.exceptions import JenkinsHelperException
 from oar.core.jenkins import JenkinsHelper
 from oar.core.notification import NotificationManager
 from oar.core.worksheet import WorksheetManager
+from oar.core.shipment import ShipmentData
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ def image_consistency_check(ctx, build_number, for_nightly):
     jh = JenkinsHelper(cs)
     nm = NotificationManager(cs)
     report = WorksheetManager(cs).get_test_report()
+    sd = ShipmentData(cs)
     am = AdvisoryManager(cs)
 
     if not build_number:
@@ -87,14 +89,13 @@ def image_consistency_check(ctx, build_number, for_nightly):
                 "image-consistency-check", build_number)
 
             if job_status == JENKINS_JOB_STATUS_SUCCESS:
-                unhealthy_advisories = am.check_advisories_grades_health()
-                if not unhealthy_advisories:
-                    report.update_task_status(
-                        LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_PASS)
+                health_data = sd.check_component_image_health()
+                unhealthy_count = health_data[1] # unhealthy_count is index 1
+                if unhealthy_count == 0:  
+                    report.update_task_status(LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_PASS)
                 else:
-                    nm.share_unhealthy_advisories(unhealthy_advisories)
-                    report.update_task_status(
-                        LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_FAIL)
+                    sd.add_image_health_summary_comment(health_data)
+                    report.update_task_status(LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_FAIL)
             elif job_status == JENKINS_JOB_STATUS_IN_PROGRESS:
                 report.update_task_status(
                     LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_INPROGRESS)


### PR DESCRIPTION
Implement functionality to:
- Extract components from shipment YAML files
- Query Pyxis API for image freshness grades
- Determine current health status of container images
- Track healthy/unhealthy components count
- Add comment to MR with the image health summary

This helps monitor the component image health status of container images being shipped.