### PR TITLE
OCPERT-136 Add logging and fix image health comment timing in consistency check

### DIFF
--- a/oar/cli/cmd_image_consistency_check.py
+++ b/oar/cli/cmd_image_consistency_check.py
@@ -90,10 +90,10 @@ def image_consistency_check(ctx, build_number, for_nightly):
 
             if job_status == JENKINS_JOB_STATUS_SUCCESS:
                 health_data = sd.check_component_image_health()
+                sd.add_image_health_summary_comment(health_data)
                 if health_data.unhealthy_count == 0:
                     report.update_task_status(LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_PASS)
                 else:
-                    sd.add_image_health_summary_comment(health_data)
                     report.update_task_status(LABEL_TASK_IMAGE_CONSISTENCY_TEST, TASK_STATUS_FAIL)
             elif job_status == JENKINS_JOB_STATUS_IN_PROGRESS:
                 report.update_task_status(


### PR DESCRIPTION
- Add detailed logging to ShipmentData.image_health_check for better debugging
- Move add_image_health_summary_comment call before status check in cmd_image_consistency_check to ensure comment is always added regardless of health status
- Track total scanned components and unhealthy count in logs