### PR TITLE
OCPERT-134 Update Jenkins stage job logic to handle Konflux flow

### DIFF
--- a/oar/core/jenkins.py
+++ b/oar/core/jenkins.py
@@ -149,8 +149,7 @@ class JenkinsHelper:
                 # Add SHIPMENT_MR_ID if shipment MR is available
                 if self.mr_id:
                     parameters_value["SHIPMENT_MR_ID"] = self.mr_id
-                # Add ERRATA_NUMBERS if errata_numbers is not empty
-                if self.errata_numbers:
+                else:
                     parameters_value["ERRATA_NUMBERS"] = self.errata_numbers
             elif (job_name == JENKINS_JOB_STAGE_PIPELINE):
                 parameters_value = {

--- a/oar/core/jenkins.py
+++ b/oar/core/jenkins.py
@@ -34,7 +34,8 @@ class JenkinsHelper:
 
     def call_stage_job(self):
         try:
-            if not self.metadata_ad:
+            # only check metadata ad for errata flow
+            if not self._cs.is_konflux_flow() and not self.metadata_ad:
                 raise JenkinsException("metadata advisory not found")
 
             build_url = self.call_build_job(
@@ -148,15 +149,18 @@ class JenkinsHelper:
                 # Add SHIPMENT_MR_ID if shipment MR is available
                 if self.mr_id:
                     parameters_value["SHIPMENT_MR_ID"] = self.mr_id
-                # Add ERRATA_NUMBERS if metadata_ad is not empty
-                if self.metadata_ad:
+                # Add ERRATA_NUMBERS if errata_numbers is not empty
+                if self.errata_numbers:
                     parameters_value["ERRATA_NUMBERS"] = self.errata_numbers
             elif (job_name == JENKINS_JOB_STAGE_PIPELINE):
                 parameters_value = {
                     "VERSION": self.version,
-                    "METADATA_AD": self.metadata_ad,
                     "PULL_SPEC": pull_spec,
                 }
+                # only add metadata ad to job request for errata release flow
+                # if param metadata_ad is not provided, stage 'Verify Metadata' will be skipped.
+                if self.metadata_ad:
+                    parameters_value["METADATA_AD"] = self.metadata_ad
             else:
                 logger.info(f"{job_name} is not supported")
 


### PR DESCRIPTION
- Skip metadata advisory check for Konflux flow in call_stage_job()
- Use errata_numbers instead of metadata_ad for ERRATA_NUMBERS parameter
- Make metadata advisory optional in stage pipeline job for non-errata flows
- Improve comments to clarify flow-specific behaviors

These changes allow the Jenkins integration to properly support both traditional errata and Konflux-based release workflows.