### PR TITLE
OCPERT-134 Refactor worksheet handling to support both advisory and shipment flows

### DIFF
--- a/oar/core/const.py
+++ b/oar/core/const.py
@@ -1,7 +1,7 @@
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 # cell labels
-LABEL_SHIPMENT = "B2"
+LABEL_AD_OR_SHIPMENT = "B2"
 LABEL_BUILD = "B3"
 LABEL_JIRA = "B4"
 LABEL_OVERALL_STATUS = "B1"


### PR DESCRIPTION
- Rename LABEL_SHIPMENT to LABEL_AD_OR_SHIPMENT to reflect dual purpose
- Split update_shipment_info into separate methods for advisory and shipment flows
- Add new update_advisory_info method for advisory-specific formatting
- Add conditional logic in WorksheetManager to handle different flows
- Improve docstrings and logging for better clarity
- Update related method names to reflect broader functionality (get_advisory_or_shipment_info)