### PR TITLE
[OCPERT-147]Add job failure state

### DIFF
--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -510,7 +510,7 @@ class ProwJobResult():
         return bool(self.job_completion_time)
 
     def is_failed(self):
-        return self.job_state == "failure" or self.job_state == "aborted"
+        return self.job_state == "failure" or self.job_state == "aborted" or self.job_state == "error"
 
     def is_success(self):
         return self.job_state == "success"


### PR DESCRIPTION
Retry jobs will not be triggered when nightly build job returned error like:

https://github.com/openshift/release-tests/blob/record/_releases/ocp-test-result-4.15.0-0.nightly-2025-08-05-232458-amd64.json

So add error into failed job state

