### PR TITLE
Update notification operator to use shipment MRs from CS

### DIFF
--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -203,7 +203,7 @@ class NotificationOperator:
         """
         try:
             if self._sd._cs.is_konflux_flow():
-                mrs = self._sd.get_merge_requests()
+                mrs = self._sd._cs.get_shipment_mrs()
                 self._nm.share_shipment_mrs_and_ad_info(
                     mrs, updated_ads, abnormal_ads, updated_subtasks, new_owner
                 )


### PR DESCRIPTION
Modify `NotificationOperator` to fetch merge requests using `_cs.get_shipment_mrs()` instead of `sd.get_merge_requests()` when handling Konflux flow notifications. This ensures consistency with the Konflux workflow by using the correct MR source.