### PR TITLE
Implement Konflux flow support for advisory status changes

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -2,18 +2,16 @@ import json
 import logging
 import re
 import subprocess
-from datetime import datetime, timezone
-
 import koji
 import urllib3
-from dateutil import parser
-from errata_tool import Erratum, ErrataException, security
-
 import oar.core.util as util
 from oar.core.configstore import ConfigStore
 from oar.core.const import *
 from oar.core.exceptions import AdvisoryException
 from oar.core.jira import JiraManager
+from datetime import datetime, timezone
+from dateutil import parser
+from errata_tool import Erratum, ErrataException, security
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+from oar.core.util import is_payload_metadata_url_accessible
+
+class TestPayloadMetadataUrlAccessible(unittest.TestCase):
+
+    def test_happy_path(self):
+        """Test successful case with Y-stream release version"""
+        self.assertFalse(is_payload_metadata_url_accessible("4.19"))
+        self.assertTrue(is_payload_metadata_url_accessible("4.18"))
+
+    @patch('oar.core.util.requests.get')
+    def test_fail_get_pullspec(self, mock_requests):
+        """Test failure to get pullspec from release stream"""
+        mock_requests.return_value.ok = False
+        mock_requests.return_value.status_code = 404
+
+        self.assertFalse(is_payload_metadata_url_accessible("4.19"))
+
+    @patch('oar.core.util.requests.get')
+    @patch('oar.core.util.subprocess.run')
+    def test_fail_oc_not_installed(self, mock_subprocess, mock_requests):
+        """Test failure when oc client is not installed"""
+        mock_requests.return_value.ok = True
+        mock_requests.return_value.json.return_value = {'pullSpec': 'test-pullspec'}
+        mock_subprocess.side_effect = FileNotFoundError()
+
+        self.assertFalse(is_payload_metadata_url_accessible("4.19"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Modify advisory status change logic to check payload metadata URL accessibility for Konflux releases
- Update approval operator to handle Konflux flow separately, only moving RPM advisory status when metadata URL is accessible
- Add utility function to check payload metadata URL accessibility
- Add tests for new utility functionality
- Clean up imports and add missing logging

The changes ensure we don't prematurely move advisories before the payload metadata URL is accessible for Konflux-based releases.