### PR TITLE
OCPERT-112 Fix variable name inconsistency in JenkinsHelper MR handling

### DIFF
--- a/oar/core/jenkins.py
+++ b/oar/core/jenkins.py
@@ -24,8 +24,8 @@ class JenkinsHelper:
             [str(i) for i in [val for val in self._cs.get_advisories().values()]]
         )
         # get shipment MR id
-        mrs = ShipmentData(cs).get_mr()
-        self.mr_id = mrs[0].get_id() if mrs else None
+        mr = ShipmentData(cs).get_mr()
+        self.mr_id = mr.get_id() if mr else None
         # construct image pull spec
         self.pull_spec = (
             "quay.io/openshift-release-dev/ocp-release:" + self._cs.release + "-x86_64"


### PR DESCRIPTION
Standardize variable naming from plural 'mrs' to singular 'mr' to match the actual data structure returned by ShipmentData.get_mr(), which returns a single object rather than a list. This improves code clarity and prevents potential confusion about the data type being handled.