### PR TITLE
OCPERT-112 Fix MR ID logging in image health check error message

### DIFF
--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -1193,7 +1193,7 @@ class ShipmentData:
                     logger.warning(f"Failed to check freshness for image: {str(e)}")
                     continue
         except Exception as e:
-            logger.error(f"Failed to process MR {mr.merge_request_id}: {str(e)}")
+            logger.error(f"Failed to process MR {self._mr.get_id()}: {str(e)}")
                 
         logger.info(f"Completed image health check. Scanned {total_scanned} images, found {len(unhealthy_components)} unhealthy")
         return ImageHealthData(


### PR DESCRIPTION
Update error logging to use `self._mr.get_id()` instead of `mr.merge_request_id` for consistency and to ensure correct MR identifier is displayed when processing fails during image health checks.