### PR TITLE
OCPERT-112 Refactor bug filtering to use unverified status instead of ON_QA

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -201,7 +201,7 @@ class AdvisoryManager:
         ads = self.get_advisories()
         all_dropped_bugs = []
         for ad in ads:
-            drop_bug_list = jm.get_onqa_issues_excluding_cve(ad.jira_issues)
+            drop_bug_list = jm.get_unverified_issues_excluding_cve(ad.jira_issues)
             if drop_bug_list:
                 all_dropped_bugs.extend(drop_bug_list)
                 for key in drop_bug_list:

--- a/oar/core/jira.py
+++ b/oar/core/jira.py
@@ -259,26 +259,26 @@ class JiraManager:
                 unverified_cve_issues.append(issue)
         return unverified_cve_issues
 
-    def get_onqa_issues_excluding_cve(self, jira_issue_keys: list[str]):
+    def get_unverified_issues_excluding_cve(self, jira_issue_keys: list[str]):
         """
-        Get list of issues in ON_QA state, excluding CVE tracker bugs
+        Get list of unverified issues (status not in verified, closed), excluding CVE tracker bugs
 
         Args:
             jira_issue_keys (list[str]): List of jira issue keys to filter
 
         Returns:
-            list[str]: List of issue keys in ON_QA state that are not CVE trackers
+            list[str]: List of issue keys that are unverified and not CVE trackers
         """
-        onqa_issues = list()
+        unverified_issues = list()
         for key in jira_issue_keys:
             try:
                 issue = self.get_issue(key)
             except JiraUnauthorizedException as e:
                 logger.error(f"Jira token does not have permission to access issue {key}, ignore and continue: {e}")
                 continue
-            if issue.is_on_qa() and not issue.is_cve_tracker():
-                onqa_issues.append(issue.get_key())
-        return onqa_issues
+            if not issue.is_finished() and not issue.is_cve_tracker():
+                unverified_issues.append(issue.get_key())
+        return unverified_issues
 
     def create_cvp_issue(self, abnormal_tests):
         """

--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -919,10 +919,10 @@ class ShipmentData:
         jira_manager = JiraManager(self._cs)
         jira_issues = self._mr.get_jira_issues()
         # get all onqa issues except cve trackers
-        onqa_issues = jira_manager.get_onqa_issues_excluding_cve(jira_issues)
+        unverified_issues = jira_manager.get_unverified_issues_excluding_cve(jira_issues)
 
         # Check if there are any onqa issues to drop
-        if not onqa_issues:
+        if not unverified_issues:
             logger.info("No ONQA issues found to drop, returning early")
             return []
 
@@ -967,7 +967,7 @@ class ShipmentData:
                     original_content = file.read()
                 
                 # Use string-based approach to remove bug items while preserving formatting
-                modified_content = self._remove_bugs_from_yaml_string(original_content, onqa_issues)
+                modified_content = self._remove_bugs_from_yaml_string(original_content, unverified_issues)
                 
                 # Only write back if content actually changed
                 if modified_content != original_content:
@@ -1002,7 +1002,7 @@ class ShipmentData:
             new_mr = gl.create_merge_request("rioliu/ocp-shipment-data", branch, self._mr.get_source_branch(), mr_title, target_project="hybrid-platforms/art/ocp-shipment-data")
             self._mr.add_comment(f"Drop bug in MR: {new_mr.get_web_url()}")
 
-        return onqa_issues
+        return unverified_issues
 
     def _remove_bugs_from_yaml_string(self, yaml_content: str, bugs_to_remove: list[str]) -> str:
         """Remove specific bug items from YAML content by identifying and removing lines.


### PR DESCRIPTION
Change Jira issue filtering logic from checking `ON_QA` status to using a broader unverified state (not verified/closed/release_pending). This provides more comprehensive coverage for identifying bugs that should be dropped from advisories, as it captures all unfinished issues rather than just those in a specific workflow state. Updated method names and documentation to reflect the new behavior.