### PR TITLE
OCPERT-158 Enhance CVE tracker bug check to include both advisory and shipment s…

### DIFF
--- a/oar/cli/cmd_check_cve_tracker_bug.py
+++ b/oar/cli/cmd_check_cve_tracker_bug.py
@@ -2,9 +2,9 @@ import logging
 
 import click
 
-from oar.core.advisory import AdvisoryManager
 from oar.core.const import *
 from oar.core.notification import NotificationManager
+from oar.core.operators import CVETrackerOperator
 from oar.core.worksheet import WorksheetManager
 
 logger = logging.getLogger(__name__)
@@ -15,28 +15,36 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 def check_cve_tracker_bug(ctx, notify):
     """
-    Check if there is any missed CVE tracker bug
+    Check if there is any missed CVE tracker bug from both advisory and shipment data
     """
     # get config store from context
     cs = ctx.obj["cs"]
     try:
         # get existing report
         report = WorksheetManager(cs).get_test_report()
-        # init advisory manager
-        am = AdvisoryManager(cs)
-        # init notification manager
-        nm = NotificationManager(cs)
+        # init CVE tracker operator
+        cve_operator = CVETrackerOperator(cs)
         # update task status to in progress
         report.update_task_status(
             LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_INPROGRESS)
-        # trigger push job for cdn stage targets
-        cve_tracker_bugs = am.check_cve_tracker_bug()
-        if len(cve_tracker_bugs):
-            appended = report.append_missed_cve_tracker_bugs(cve_tracker_bugs)
+        # Check for missed CVE tracker bugs from both advisory and shipment sources
+        advisory_cve_bugs, shipment_cve_bugs = cve_operator.check_cve_tracker_bugs()
+        all_cve_bugs = advisory_cve_bugs + shipment_cve_bugs
+        
+        if len(all_cve_bugs):
+            # Log the source of the missed bugs for debugging
+            if advisory_cve_bugs:
+                logger.info(f"Found {len(advisory_cve_bugs)} missed CVE tracker bugs in advisories: {advisory_cve_bugs}")
+            if shipment_cve_bugs:
+                logger.info(f"Found {len(shipment_cve_bugs)} missed CVE tracker bugs in shipments: {shipment_cve_bugs}")
+            
+            appended = report.append_missed_cve_tracker_bugs(all_cve_bugs)
             if notify and appended:
-                nm.share_new_cve_tracker_bugs(cve_tracker_bugs)
+                # Share notification about all missed CVE tracker bugs
+                cve_operator.share_new_cve_tracker_bugs(all_cve_bugs)
         else:
-            logger.info("no new CVE tracker bug found")
+            logger.info("no new CVE tracker bug found in either advisories or shipments")
+        
         report.update_task_status(
             LABEL_TASK_CHECK_CVE_TRACKERS, TASK_STATUS_PASS)
     except Exception as e:

--- a/tests/test_shipment.py
+++ b/tests/test_shipment.py
@@ -8,6 +8,7 @@ from oar.core.exceptions import (
     ShipmentDataException,
     GitLabMergeRequestException
 )
+from oar.core.configstore import ConfigStore
 
 
 class TestGitLabServer(unittest.TestCase):
@@ -429,7 +430,7 @@ class TestShipmentData(unittest.TestCase):
     def setUp(self, mock_config):
         self.mock_config = mock_config
         self.mock_config.get_gitlab_url.return_value = "https://gitlab.cee.redhat.com"
-        self.mock_config.get_shipment_mr.return_value = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/68"
+        self.mock_config.get_shipment_mr.return_value = "https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/91"
         # Don't mock the token - let it be retrieved from environment  
         self.mock_config.get_gitlab_token.return_value = os.getenv('GITLAB_TOKEN')
         self.shipment = ShipmentData(self.mock_config)
@@ -592,6 +593,12 @@ class TestShipmentData(unittest.TestCase):
                     "Merge request 15 not found - skipping real API test")
             else:
                 self.fail(f"Failed to test Jira issue line numbers: {str(e)}")
+
+    def test_check_cve_tracker_bug(self):
+        cs = ConfigStore("4.18.23")
+        sd = ShipmentData(cs)
+        missed_trackers = sd.check_cve_tracker_bug()
+        self.assertTrue(len(missed_trackers) == 0)
 
 
 class TestShipmentImageHealth(unittest.TestCase):


### PR DESCRIPTION
…ources

Refactor the CVE tracker bug checking logic to consolidate advisory and shipment data sources into a unified operator. Update elliott command parameters and improve logging to clearly identify the source of missed bugs. This provides more comprehensive coverage when detecting unattached CVE tracker bugs across different data sources.