### PR TITLE
OCPERT-158 Add --permissive flag to elliott command in advisory manager

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -245,6 +245,7 @@ class AdvisoryManager:
             "--cve-only",
             "--output",
             "json",
+            "--permissive"
         ]
 
         logger.debug(f"elliott cmd {cmd}")


### PR DESCRIPTION
Include the `--permissive` option when running elliott to handle advisory operations more flexibly, allowing the command to succeed even when non-critical validation checks fail. 