### PR TITLE
OCPERT-159 Add timeout and retry logic for payload metadata accessibility check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ dependencies = [
     
     # Utilities
     "glom >= 23.1.1",
-    "GitPython >= 3.1.40"
+    "GitPython >= 3.1.40",
+    "schedule >= 1.2.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Introduce a 2-day timeout period with scheduled retries every 30 minutes when checking payload metadata URL accessibility in ApprovalOperator. Previously the operator would immediately fail if the metadata wasn't accessible. Now it waits for the URL to become available before proceeding with advisory status changes. Added schedule dependency to support the retry mechanism.