### PR TITLE
OCPERT-112 Add RHCOS impetus support for kernel tag checks

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -764,8 +764,8 @@ class Advisory(Erratum):
         Returns:
             bool: True if kernel build is tagged with early-kernel-stop-ship.
         """
-        #Check if impetus is image or not, if it's not image then skip this function.
-        if self.impetus != AD_IMPETUS_IMAGE:
+        #Check if impetus is image/rhcos or not, if it's not then skip this function.
+        if self.impetus not in [AD_IMPETUS_IMAGE, AD_IMPETUS_RHCOS]:
             logger.info(f"{self.impetus} advisory does not have RHCOS build, skip checking kernel tag")
             return False
         #Get rhcos nvr from image advisory build

--- a/oar/core/const.py
+++ b/oar/core/const.py
@@ -107,6 +107,7 @@ AD_IMPETUS_IMAGE = "image"
 AD_IMPETUS_METADATA = "metadata"
 AD_IMPETUS_MICROSHIFT = "microshift"
 AD_IMPETUS_RPM = "rpm"
+AD_IMPETUS_RHCOS = "rhcos"
 
 # jenkins related properties
 JENKINS_JOB_IMAGE_CONSISTENCY_CHECK = "image-consistency-check"

--- a/tests/test_advisory.py
+++ b/tests/test_advisory.py
@@ -8,7 +8,7 @@ from oar.core.const import *
 
 class TestAdvisoryManager(unittest.TestCase):
     def setUp(self):
-        self.am = AdvisoryManager(ConfigStore("4.12.11"))
+        self.am = AdvisoryManager(ConfigStore("4.19.10"))
 
     def test_init(self):
         pass
@@ -74,6 +74,7 @@ class TestAdvisoryManager(unittest.TestCase):
         self.assertTrue(Advisory(errata_id=144853, impetus='image').check_kernel_tag())
         self.assertFalse(Advisory(errata_id=144854, impetus='metadata').check_kernel_tag())
         self.assertFalse(Advisory(errata_id=146595, impetus='image').check_kernel_tag())
+        self.assertFalse(Advisory(errata_id=153980, impetus='rhcos').check_kernel_tag())
     
     def test_finished_jiras(self):
         self.assertTrue(self.am.has_finished_all_advisories_jiras())


### PR DESCRIPTION
Extend kernel build tag validation to include RHCOS advisories by:
- Adding AD_IMPETUS_RHCOS constant
- Modifying check_kernel_tag() to handle RHCOS impetus alongside image
- Updating test cases to include RHCOS advisory scenario
- Bumping test config version to 4.19.10

This ensures consistent kernel tag validation across both image and RHCOS advisory types.