### PR TITLE
OCPERT-162 Set daemon=False for background process to ensure cleanup completion

### DIFF
--- a/docs/ASYNC_APPROVAL_IMPLEMENTATION.md
+++ b/docs/ASYNC_APPROVAL_IMPLEMENTATION.md
@@ -17,7 +17,7 @@ This document describes the new async implementation for the `approve_release` f
 
 **Return Values**:
 - `True`: Metadata URL accessible immediately, advisories moved to REL_PREP
-- `"SCHEDULED"`: Background process started for periodic checking
+- `"SCHEDULED"`: Background process started for periodic checking (process continues after parent exit on Unix/Linux)
 - `False`: Scheduler already running (lock file exists)
 
 ### 2. Added Background Worker Function

--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -375,6 +375,7 @@ class ApprovalOperator:
                     target=self._background_metadata_checker,
                     args=(minor_release,)
                 )
+                process.daemon = False  # Allow process to complete cleanup and timeout handling (non-daemon processes continue after parent exit on Unix/Linux)
                 process.start()
                 
                 logger.info(f"Background metadata checker process started (PID: {process.pid})")


### PR DESCRIPTION
Modify async approval implementation to set `process.daemon=False`, allowing background metadata checker processes to complete cleanup and timeout handling after parent process exit on Unix/Linux systems. Update documentation to reflect this behavior change for the "SCHEDULED" return value.