### PR TITLE
OCPERT-162 Detach background processes for immediate feedback

### DIFF
--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -385,8 +385,19 @@ class ApprovalOperator:
                 env = os.environ.copy()
                 
                 # Start the process with start_new_session=True for true independence
-                process = subprocess.Popen(cmd, start_new_session=True, env=env)
+                # This creates a completely detached process that won't become a zombie
+                # We don't redirect stdout/stderr to allow the parent process to capture output
+                process = subprocess.Popen(
+                    cmd, 
+                    start_new_session=True, 
+                    env=env,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    stdin=subprocess.DEVNULL
+                )
                 
+                # The process is now completely detached and won't become a zombie
+                # We don't need to wait for it or terminate it
                 logger.info(f"Background metadata checker process started (PID: {process.pid}) - running independently after parent exit")
                 return "SCHEDULED"
             else:


### PR DESCRIPTION
Corrects a race condition where the parent process hangs, preventing it from sending immediate feedback to the Slack app. By redirecting the standard I/O streams of the grandchild process to /dev/null, we ensure it fully detaches, allowing the parent to exit gracefully and its output to be captured.

This change ensures that:
The Slack app receives a "scheduled" message promptly. The background task runs independently without blocking the main process. The final result is still delivered to Slack by the long-running background process.