### PR TITLE
Redirect background process output to log files for debugging

### DIFF
--- a/tools/slack_message_receiver.py
+++ b/tools/slack_message_receiver.py
@@ -13,7 +13,7 @@ from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web import WebClient
 
 logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("QEReleaseBot")
+logger = logging.getLogger("ERTReleaseBot")
 
 
 # Initialize SocketModeClient with an app-level token + WebClient
@@ -92,7 +92,7 @@ def process(client: SocketModeClient, req: SocketModeRequest):
         thread_ts = event["ts"]
         username = get_username(event["user"])
 
-        if username == "qe-release-bot":
+        if username == "ert-release-bot":
             return
 
         if event_type in ["message", "app_mention"]:
@@ -100,7 +100,7 @@ def process(client: SocketModeClient, req: SocketModeRequest):
                 client.web_client.chat_postMessage(
                     channel=channel_id,
                     thread_ts=thread_ts,
-                    text="I'm qe release bot",
+                    text="I'm ERT release bot",
                 )
 
             # slack will transform the email address in message with mailto format e.g. <mailto:xx@foo.com|xx@foo.com>


### PR DESCRIPTION
Previously, the background metadata checker process had stdout/stderr redirected to DEVNULL, making debugging difficult. This change:
- Creates timestamped log files in a temporary directory
- Redirects both stdout and stderr to these log files
- Adds initial metadata to log files for traceability
- Updates logging to include the log file location

Additionally, updates Slack bot references from "QE" to "ERT" branding:
- Changes logger name from "QEReleaseBot" to "ERTReleaseBot"
- Updates username check from "qe-release-bot" to "ert-release-bot"
- Updates response message text to "I'm ERT release bot"