### PR TITLE
OCPERT-167 improve CVE tracker bug logging and fix variable references

### DIFF
--- a/oar/cli/cmd_check_cve_tracker_bug.py
+++ b/oar/cli/cmd_check_cve_tracker_bug.py
@@ -34,9 +34,9 @@ def check_cve_tracker_bug(ctx, notify):
         if len(all_cve_bugs):
             # Log the source of the missed bugs for debugging
             if advisory_cve_bugs:
-                logger.info(f"Found {len(advisory_cve_bugs)} missed CVE tracker bugs in advisories: {advisory_cve_bugs}")
+                logger.info(f"Found {len(advisory_cve_bugs)} missed CVE tracker bugs in advisories: {[str(bug) for bug in advisory_cve_bugs]}")
             if shipment_cve_bugs:
-                logger.info(f"Found {len(shipment_cve_bugs)} missed CVE tracker bugs in shipments: {shipment_cve_bugs}")
+                logger.info(f"Found {len(shipment_cve_bugs)} missed CVE tracker bugs in shipments: {[str(bug) for bug in shipment_cve_bugs]}")
             
             appended = report.append_missed_cve_tracker_bugs(all_cve_bugs)
             if notify and appended:

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -270,9 +270,9 @@ class AdvisoryManager:
                 if isinstance(trackers, list):
                     for tracker in trackers:
                         # add it to missed bug list if it is not attached on advisories
-                        if id not in rhsa_jira_issues:
+                        if tracker not in rhsa_jira_issues:
                             logger.info(f"CVE tracker bug {tracker} is not found in RHSA advisories")
-                            cve_tracker_bugs.append(id)
+                            cve_tracker_bugs.append(tracker)
 
         return cve_tracker_bugs
 

--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -1384,6 +1384,6 @@ class ShipmentData:
                         # add it to missed bug list if it is not found in shipment yamls
                         if tracker not in shipment_jira_issues:
                             logger.info(f"Missed CVE tracker bug {tracker} is not found in shipment data")
-                            cve_tracker_bugs.append(id)
+                            cve_tracker_bugs.append(tracker)
 
         return cve_tracker_bugs


### PR DESCRIPTION
- Convert CVE tracker bug objects to strings in log messages for better readability
- Fix variable references in advisory.py and shipment.py to use 'tracker' instead of 'id'
- This ensures correct bug tracking and clearer debug output when checking for missed CVE tracker bugs