### PR TITLE
Rollback bot user name check

### DIFF
--- a/tools/slack_message_receiver.py
+++ b/tools/slack_message_receiver.py
@@ -92,7 +92,7 @@ def process(client: SocketModeClient, req: SocketModeRequest):
         thread_ts = event["ts"]
         username = get_username(event["user"])
 
-        if username == "ert-release-bot":
+        if username == "qe-release-bot":
             return
 
         if event_type in ["message", "app_mention"]:


### PR DESCRIPTION
even the display name of bot user can be changed, but internal name cannot be changed.