### PR TITLE
Fix MCP server command in docs

### DIFF
--- a/deployment/MCP_SERVER_DEPLOYMENT.md
+++ b/deployment/MCP_SERVER_DEPLOYMENT.md
@@ -65,7 +65,7 @@ source ~/.bash_profile
 echo $OAR_JWK  # Should print your JWK key
 
 # Test the server (Ctrl+C to stop)
-python3 -m mcp.server
+python3 -m mcp_server.server
 ```
 
 You should see:

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -37,8 +37,11 @@ The MCP server:
 # Ensure credentials are loaded
 source ~/.bash_profile
 
+# Navigate to mcp_server directory
+cd mcp_server/
+
 # Run the server
-python3 -m mcp.server
+python3 server.py
 ```
 
 ### Deploying on VM


### PR DESCRIPTION
Fix incorrect MCP server module path in documentation

  - deployment/MCP_SERVER_DEPLOYMENT.md: Correct python3 -m mcp.server to python3 -m mcp_server.server
  - mcp_server/README.md: Change to python3 server.py with proper directory context

  The module path 'mcp.server' does not exist; correct path is 'mcp_server.server'