### PR TITLE
Skip notification for pre-merge verified bugs in Jira notificator

### DIFF
--- a/oar/notificator/jira_notificator.py
+++ b/oar/notificator/jira_notificator.py
@@ -1,6 +1,7 @@
 import click
 import logging
 import os
+import re
 
 from enum import Enum
 from typing import List, Optional, Dict
@@ -8,6 +9,7 @@ from jira import JIRA, Issue
 from jira.resources import User
 from datetime import datetime, timedelta, timezone
 from dateutil import parser
+from github import Auth, Github
 from oar.core.jira import JiraIssue
 from oar.core.ldap import LdapHelper
 
@@ -71,6 +73,8 @@ class NotificationService:
         self.jira = jira
         self.dry_run = dry_run
         self.ldap = LdapHelper()
+        github_token = os.environ.get("GITHUB_TOKEN", "")
+        self.github = Github(auth=Auth.Token(github_token)) if github_token else None
 
     def get_user_email(self, user: User) -> Optional[str]:
         """
@@ -579,6 +583,10 @@ class NotificationService:
             Optional[Notification]: The created notification if sent, otherwise None.
         """
 
+        if self.is_pre_merge_verified(issue):
+            logger.info(f"Issue {issue.key} is pre-merge verified. Skipping notification.")
+            return None
+
         on_qa_datetime = self.get_latest_on_qa_transition_datetime(issue)
         if not on_qa_datetime:
             logger.error(f"Issue {issue.key} does not have ON_QA transition date")
@@ -620,6 +628,58 @@ class NotificationService:
                 logger.info("Skipping adding ON_QA pending label - less than 24 hour from Manager notification.")
 
         return None
+
+    def is_pre_merge_verified(self, issue: Issue) -> bool:
+        """
+        Check if all linked GitHub PRs from the openshift org are pre-merge verified.
+
+        A bug is considered pre-merge verified only when:
+        - There is at least one valid PR (github.com/openshift org)
+        - Every valid PR has the 'verified' label
+        - No valid PR has the 'verified-later' label (which indicates post-merge verification is needed)
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+
+        Returns:
+            bool: True if all valid PRs are pre-merge verified, False otherwise.
+        """
+        if not self.github:
+            logger.warning("GITHUB_TOKEN not set, skipping pre-merge verification check.")
+            return False
+
+        try:
+            remote_links = self.jira.remote_links(issue)
+        except Exception as e:
+            logger.warning(f"Failed to fetch remote links for {issue.key}: {e}")
+            return False
+
+        valid_prs = []
+        for link in remote_links:
+            url = getattr(link.object, "url", "")
+            match = re.match(r"https://github\.com/(openshift)/([^/]+)/pull/(\d+)", url)
+            if match:
+                valid_prs.append((url, match.group(1), match.group(2), int(match.group(3))))
+
+        if not valid_prs:
+            return False
+
+        for url, org, repo, pr_number in valid_prs:
+            try:
+                pr = self.github.get_repo(f"{org}/{repo}").get_pull(pr_number)
+                labels = {label.name for label in pr.get_labels()}
+                if "verified-later" in labels:
+                    logger.info(f"Issue {issue.key} PR {url} has 'verified-later' label, post-merge verification needed.")
+                    return False
+                if "verified" not in labels:
+                    logger.info(f"Issue {issue.key} PR {url} has neither 'verified' nor 'verified-later' label.")
+                    return False
+            except Exception as e:
+                logger.warning(f"Failed to check PR labels for {url}: {e}")
+                return False
+
+        logger.info(f"Issue {issue.key} is pre-merge verified across all {len(valid_prs)} linked PR(s).")
+        return True
 
     def get_on_qa_filter(self, from_date: Optional[datetime] = None) -> str:
         """

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -407,6 +407,28 @@ class TestJiraNotificator(unittest.TestCase):
             self.assertEqual(notification.issue, self.test_issue_on_qa)
             self.assertIn(ERT_NOTIFICATION_PREFIX, notification.text)
 
+    def test_is_pre_merge_verified(self):
+        # OCPBUGS-76269: linked PR openshift/cluster-olm-operator#170 has 'verified' label only -> pre-merge verified
+        issue_pre_merge_verified = self.jira.issue("OCPBUGS-76269")
+        self.assertTrue(self.ns.is_pre_merge_verified(issue_pre_merge_verified))
+
+        # OCPBUGS-81573: linked PR openshift/insights-operator#1266 has both 'verified' and 'verified-later' -> post-merge verified
+        issue_verified_later = self.jira.issue("OCPBUGS-81573")
+        self.assertFalse(self.ns.is_pre_merge_verified(issue_verified_later))
+
+        # OCPBUGS-81481: linked PR openshift/linuxptp-daemon#581 has both 'verified' and 'verified-later' -> post-merge verified
+        issue_verified_later_2 = self.jira.issue("OCPBUGS-81481")
+        self.assertFalse(self.ns.is_pre_merge_verified(issue_verified_later_2))
+
+        # OCPBUGS-59288: no remote links -> no valid PRs -> not pre-merge verified
+        issue_no_links = self.jira.issue("OCPBUGS-59288")
+        self.assertFalse(self.ns.is_pre_merge_verified(issue_no_links))
+
+        # No GITHUB_TOKEN -> skip check, return False
+        ns_no_token = NotificationService(self.jira, True)
+        ns_no_token.github = None
+        self.assertFalse(ns_no_token.is_pre_merge_verified(issue_pre_merge_verified))
+
     def test_process_on_qa_issues(self):
         day_ago = datetime.now() - timedelta(hours=24)
         self.assertEqual(len(self.ns.process_on_qa_issues(day_ago)), 0)


### PR DESCRIPTION
## Summary

- Add `is_pre_merge_verified()` to `NotificationService` which checks all linked GitHub PRs from the `openshift` org via Jira remote links
- A bug is considered pre-merge verified when all valid PRs have the `verified` label and none have `verified-later`
- Skip the alert comment early in `check_issue_and_notify_responsible_people()` for pre-merge verified bugs, since QA cannot act until an accepted payload is available
- Add unit tests using real issues: OCPBUGS-76269 (pre-merge verified), OCPBUGS-81573 and OCPBUGS-81481 (verified-later), OCPBUGS-59288 (no linked PRs)

Fixes: [OCPERT-357](https://redhat.atlassian.net/browse/OCPERT-357)