### PR TITLE
Fall back to reporter notification when issue has no QA contact or assignee

### DIFF
--- a/oar/notificator/jira_notificator.py
+++ b/oar/notificator/jira_notificator.py
@@ -25,6 +25,7 @@ class NotificationType(Enum):
     TEAM_LEAD = (48, "Team Lead Action Request")
     MANAGER = (72, "Manager Action Request")
     ASSIGNEE = (24, "Assignee Action Request")
+    REPORTER = (24, "Reporter Action Request")
 
     def __init__(self, hours: int, label: str):
         self.hours = hours
@@ -305,6 +306,7 @@ class NotificationService:
     def notify_assignees(self, issue: Issue, missing_contact: Contact) -> Optional[Notification]:
         """
         Notifies assignees about a missing contact on an issue, if not already notified.
+        If no assignee exists, falls back to notifying the reporter.
 
         Args:
             issue (Issue): The issue related to the notification.
@@ -312,9 +314,6 @@ class NotificationService:
 
         Returns:
             Optional[Notification]: The created notification if sent, otherwise None.
-
-        Raises:
-            Exception: If no assignee is available on the issue.
         """
 
         if not self.has_assignee_notification(issue):
@@ -327,17 +326,62 @@ class NotificationService:
                     notified_assignees.append(assignee_manager)
                     self.add_user_to_need_info_from(issue, assignee_manager)
                 assignee_notification = Notification(
-                    issue, 
-                    NotificationType.ASSIGNEE, 
+                    issue,
+                    NotificationType.ASSIGNEE,
                     self.create_assignee_notification_text(missing_contact, notified_assignees)
                 )
                 self.process_notification(assignee_notification)
                 return assignee_notification
             else:
-                raise Exception(f"No contact is available. Issue {issue.key} does not have assignee.")
+                logger.warning(f"Issue {issue.key} has no assignee. Falling back to notifying the reporter.")
+                return self.notify_reporter(issue)
         else:
             logger.warning(f"Assignees have already been notified about the missing {missing_contact.value} contact.")
         return None
+
+    def has_reporter_notification(self, issue: Issue) -> bool:
+        """
+        Checks if the issue already contains a reporter notification comment.
+
+        Args:
+            issue (Issue): The JIRA issue to inspect.
+
+        Returns:
+            bool: True if a reporter notification comment is found, False otherwise.
+        """
+
+        for comment in issue.fields.comment.comments:
+            if comment.body.startswith(self.create_notification_title(NotificationType.REPORTER)):
+                return True
+        return False
+
+    def notify_reporter(self, issue: Issue) -> Optional[Notification]:
+        """
+        Notifies the reporter of the issue when no QA contact or assignee is available,
+        asking them to assign someone who can verify the issue.
+
+        Args:
+            issue (Issue): The JIRA issue to notify the reporter on.
+
+        Returns:
+            Optional[Notification]: The created notification if sent, otherwise None.
+        """
+
+        if self.has_reporter_notification(issue):
+            logger.warning(f"Reporter has already been notified for issue {issue.key}.")
+            return None
+
+        reporter = issue.fields.reporter
+        self.add_user_to_need_info_from(issue, reporter)
+        text = (
+            f"{self.create_notification_title(NotificationType.REPORTER)}"
+            f"{self.create_jira_comment_mentions([reporter])}"
+            f"This issue has no QA contact or assignee. "
+            f"Could you please assign someone who can verify the issue?"
+        )
+        reporter_notification = Notification(issue, NotificationType.REPORTER, text)
+        self.process_notification(reporter_notification)
+        return reporter_notification
 
     def create_qa_notification_text(self, qa_contact: User) -> str:
         """

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -18,7 +18,7 @@ class TestJiraNotificator(unittest.TestCase):
 
         self.test_issue = self.jira.issue("OCPBUGS-59288", expand="changelog")
         self.test_issue_without_qa = self.jira.issue("OCPBUGS-8760", expand="changelog")
-        self.test_issue_without_assignee = self.jira.issue("OCPBUGS-1542", expand="changelog")
+        self.test_issue_without_assignee = self.jira.issue("OCPBUGS-8827", expand="changelog")
         self.test_issue_on_qa = self.jira.issue("OCPBUGS-46472", expand="changelog")
 
         self.test_user = Mock()
@@ -197,7 +197,7 @@ class TestJiraNotificator(unittest.TestCase):
         )
 
         mock_issue = self._make_issue_without_assignee_or_qa()
-        reporter_mention = f"[~accountId:{mock_issue.fields.reporter.accountId}] "
+        reporter_mention = f"[~{mock_issue.fields.reporter.name}] "
         reporter_notification = self.ns.notify_assignees(mock_issue, Contact.QA_CONTACT)
         self.assertEqual(reporter_notification.issue, mock_issue)
         self.assertEqual(reporter_notification.type, NotificationType.REPORTER)
@@ -213,11 +213,12 @@ class TestJiraNotificator(unittest.TestCase):
     def _make_issue_without_assignee_or_qa(self):
         """Creates a mock issue with no assignee, no QA contact, but with a reporter."""
         reporter = Mock()
-        reporter.accountId = "reporter-account-id"
+        reporter.name = "reporter-username"
+        reporter.emailAddress = "reporter@redhat.com"
 
         fields = Mock()
         fields.assignee = None
-        fields.customfield_10470 = None
+        fields.customfield_12315948 = None  # QA contact field used by get_qa_contact()
         fields.reporter = reporter
         fields.comment.comments = []
 
@@ -240,7 +241,7 @@ class TestJiraNotificator(unittest.TestCase):
 
     def test_notify_reporter(self):
         issue = self._make_issue_without_assignee_or_qa()
-        reporter_mention = f"[~accountId:{issue.fields.reporter.accountId}] "
+        reporter_mention = f"[~{issue.fields.reporter.name}] "
 
         notification = self.ns.notify_reporter(issue)
         self.assertEqual(notification.issue, issue)

--- a/tests/test_jira_notificator.py
+++ b/tests/test_jira_notificator.py
@@ -196,9 +196,69 @@ class TestJiraNotificator(unittest.TestCase):
             )
         )
 
-        with self.assertRaises(Exception) as context:
-            self.ns.notify_assignees(self.test_issue_without_assignee, Contact.QA_CONTACT)
-        self.assertEqual(str(context.exception), f"No contact is available. Issue {self.test_issue_without_assignee.key} does not have assignee.")
+        mock_issue = self._make_issue_without_assignee_or_qa()
+        reporter_mention = f"[~accountId:{mock_issue.fields.reporter.accountId}] "
+        reporter_notification = self.ns.notify_assignees(mock_issue, Contact.QA_CONTACT)
+        self.assertEqual(reporter_notification.issue, mock_issue)
+        self.assertEqual(reporter_notification.type, NotificationType.REPORTER)
+        self.assertEqual(reporter_notification.text, (
+                "Errata Reliability Team Notification - Reporter Action Request\n"
+                "This issue has been in the ON_QA state for over 24 hours.\n"
+                f"{reporter_mention}"
+                "This issue has no QA contact or assignee. "
+                "Could you please assign someone who can verify the issue?"
+            )
+        )
+
+    def _make_issue_without_assignee_or_qa(self):
+        """Creates a mock issue with no assignee, no QA contact, but with a reporter."""
+        reporter = Mock()
+        reporter.accountId = "reporter-account-id"
+
+        fields = Mock()
+        fields.assignee = None
+        fields.customfield_10470 = None
+        fields.reporter = reporter
+        fields.comment.comments = []
+
+        issue = Mock()
+        issue.key = "OCPBUGS-99999"
+        issue.fields = fields
+        return issue
+
+    def test_has_reporter_notification(self):
+        issue = self._make_issue_without_assignee_or_qa()
+
+        # No comments -> no reporter notification
+        self.assertFalse(self.ns.has_reporter_notification(issue))
+
+        # Add a matching reporter notification comment
+        comment = Mock()
+        comment.body = self.ns.create_notification_title(NotificationType.REPORTER) + "some text"
+        issue.fields.comment.comments = [comment]
+        self.assertTrue(self.ns.has_reporter_notification(issue))
+
+    def test_notify_reporter(self):
+        issue = self._make_issue_without_assignee_or_qa()
+        reporter_mention = f"[~accountId:{issue.fields.reporter.accountId}] "
+
+        notification = self.ns.notify_reporter(issue)
+        self.assertEqual(notification.issue, issue)
+        self.assertEqual(notification.type, NotificationType.REPORTER)
+        self.assertEqual(notification.text, (
+                "Errata Reliability Team Notification - Reporter Action Request\n"
+                "This issue has been in the ON_QA state for over 24 hours.\n"
+                f"{reporter_mention}"
+                "This issue has no QA contact or assignee. "
+                "Could you please assign someone who can verify the issue?"
+            )
+        )
+
+        # Already notified: has_reporter_notification returns True -> return None
+        comment = Mock()
+        comment.body = self.ns.create_notification_title(NotificationType.REPORTER) + "some text"
+        issue.fields.comment.comments = [comment]
+        self.assertIsNone(self.ns.notify_reporter(issue))
 
     def test_create_qa_notification_text(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary

- When an issue has no QA contact and no assignee, the notificator was raising an exception that terminated the entire run (all subsequent issues were skipped)
- Add `notify_reporter()` fallback: posts a comment tagging the reporter asking them to assign someone for verification
- Add `NotificationType.REPORTER` and `has_reporter_notification()` for idempotent deduplication
- Update unit tests to use mocked issues for the no-assignee scenario (stable regardless of real Jira issue state)

Fixes: https://redhat.atlassian.net/browse/OCPERT-359
Failed job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-tests-main-jira-notificator/2039916376151298048