### PR TITLE
Switch nightly upgrade job to nightly-4.22-upgrade-from-stable-4.22 variant

### DIFF
--- a/_releases/ocp-4.22-test-jobs-amd64.json
+++ b/_releases/ocp-4.22-test-jobs-amd64.json
@@ -17,7 +17,7 @@
       "upgrade": true
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.22-automated-release-stable-4.22-upgrade-from-stable-4.22-aws-ipi-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.22-automated-release-nightly-4.22-upgrade-from-stable-4.22-aws-ipi-f999",
       "upgrade": true
     }
   ],


### PR DESCRIPTION
## Summary

Update `_releases/ocp-4.22-test-jobs-amd64.json` to use the new dedicated nightly upgrade variant job instead of the stable-to-stable job for nightly upgrade testing.

## Problem

The nightly section was referencing `automated-release-stable-4.22-upgrade-from-stable-4.22-aws-ipi-f999`, which sets `OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: ""`. This caused upgrade failures when testing stable-to-nightly paths because nightly images are unsigned and the image policy enforcement blocked the `openshift-config-operator` pod from rolling out.

## Changes

- Replace `periodic-ci-openshift-openshift-tests-private-release-4.22-automated-release-stable-4.22-upgrade-from-stable-4.22-aws-ipi-f999` with `periodic-ci-openshift-openshift-tests-private-release-4.22-automated-release-nightly-4.22-upgrade-from-stable-4.22-aws-ipi-f999` in the nightly section

## Dependency

Depends on openshift/release PR https://github.com/openshift/release/pull/77382 adding the new variant. 

## Jira
https://redhat.atlassian.net/browse/OCPERT-352