### PR TITLE
OCPERT-388: Update shipment source references from issues.redhat.com to redhat.atlassian.net

### DIFF
--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -147,8 +147,7 @@ class GitLabMergeRequest:
             
             # Add valid issues to our set
             for issue in fixed_issues:
-                # TODO: Update source value to 'redhat.atlassian.net' once Konflux shipment YAML is updated
-                if isinstance(issue, dict) and issue.get('source') == 'issues.redhat.com':
+                if isinstance(issue, dict) and issue.get('source') == 'redhat.atlassian.net':
                     issues.add(issue['id'])
                     
         except (yaml.YAMLError, KeyError, glom.PathAccessError) as e:
@@ -924,10 +923,8 @@ class ShipmentData:
         return self._mr
 
     def get_jira_issues(self) -> List[str]:
-        """Get Jira issue IDs from shipment YAML files where source is issues.redhat.com
+        """Get Jira issue IDs from shipment YAML files where source is redhat.atlassian.net
 
-        TODO: Update source reference to 'redhat.atlassian.net' once Konflux shipment YAML is updated
-        
         Returns:
             List[str]: Sorted list of unique Jira issue IDs (e.g. ["OCPBUGS-123", "OCPBUGS-456"])
             
@@ -1158,8 +1155,7 @@ class ShipmentData:
                 if f'id: {bug_id}' in line and line.strip().startswith('-'):
                     # Mark this line and the next line (which should contain source) for removal
                     lines_to_remove.add(i)
-                    # TODO: Update source value to 'redhat.atlassian.net' once Konflux shipment YAML is updated
-                    if i + 1 < len(lines) and 'source: issues.redhat.com' in lines[i + 1]:
+                    if i + 1 < len(lines) and 'source: redhat.atlassian.net' in lines[i + 1]:
                         lines_to_remove.add(i + 1)
         
         # Build new content without the removed lines


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPERT-388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Jira issue identification in shipment YAML files to use the updated source identifier, improving how fixed-issues entries are recognized and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->