### PR TITLE
OCPERT-389: Elliott find-bugs --cve-only returns empty results when JIRA_EMAIL is not set

### DIFF
--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 import subprocess
 import koji
@@ -250,7 +251,14 @@ class AdvisoryManager:
 
         logger.debug(f"elliott cmd {cmd}")
 
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set
+        # Set JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure
+        env = os.environ.copy()
+        if "JIRA_USERNAME" in env:
+            env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
+            logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
+
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise AdvisoryException(f"elliott cmd error:\n {stderr}")

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import re
 import subprocess
 import koji

--- a/oar/core/advisory.py
+++ b/oar/core/advisory.py
@@ -251,14 +251,7 @@ class AdvisoryManager:
 
         logger.debug(f"elliott cmd {cmd}")
 
-        # WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set
-        # Set JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure
-        env = os.environ.copy()
-        if "JIRA_USERNAME" in env:
-            env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
-            logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
-
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=util.get_elliott_env())
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise AdvisoryException(f"elliott cmd error:\n {stderr}")

--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -1526,7 +1526,14 @@ class ShipmentData:
 
         logger.debug(f"elliott cmd {cmd}")
 
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set
+        # Set JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure
+        env = os.environ.copy()
+        if "JIRA_USERNAME" in env:
+            env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
+            logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
+
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise ShipmentDataException(f"elliott cmd error:\n {stderr}")

--- a/oar/core/shipment.py
+++ b/oar/core/shipment.py
@@ -14,7 +14,7 @@ from gitlab.exceptions import (
     GitlabCreateError,
     GitlabListError
 )
-from oar.core.util import is_valid_email, parse_mr_url, get_y_release, get_release_key
+from oar.core.util import is_valid_email, parse_mr_url, get_y_release, get_release_key, get_elliott_env
 from typing import List, Optional, Set
 from glom import glom
 from oar.core.configstore import ConfigStore
@@ -1526,14 +1526,7 @@ class ShipmentData:
 
         logger.debug(f"elliott cmd {cmd}")
 
-        # WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set
-        # Set JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure
-        env = os.environ.copy()
-        if "JIRA_USERNAME" in env:
-            env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
-            logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
-
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=get_elliott_env())
         stdout, stderr = p.communicate()
         if p.returncode != 0:
             raise ShipmentDataException(f"elliott cmd error:\n {stderr}")

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -222,21 +222,44 @@ def split_large_message(message: str, max_size: int = 4000, chunk_size: int = 25
     
     return chunks
 
+def get_elliott_env():
+    """Get environment dict with Elliott JIRA workaround applied.
+
+    WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set.
+    This function sets JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure.
+
+    Returns:
+        dict: Copy of os.environ with JIRA_EMAIL set if JIRA_USERNAME exists
+
+    Example:
+        >>> import subprocess
+        >>> cmd = ['elliott', 'find-bugs', '--cve-only']
+        >>> p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=get_elliott_env())
+    """
+    import os
+
+    env = os.environ.copy()
+    if "JIRA_USERNAME" in env:
+        env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
+        logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
+
+    return env
+
 def is_payload_metadata_url_accessible(release: str) -> bool:
     """Check if the metadata URL for a given OCP release payload is accessible.
-    
+
     This function verifies accessibility by:
     1. Getting the image pullspec from release stream API
     2. Checking if oc client is available
     3. Extracting metadata URL from release payload
     4. Verifying the metadata URL returns HTTP 200
-    
+
     Args:
         release: The OCP Y-stream release version to check (e.g. "4.19")
-        
+
     Returns:
         bool: True if metadata URL is accessible, False otherwise
-        
+
     Raises:
         requests.exceptions.RequestException: If any HTTP request fails
         subprocess.CalledProcessError: If oc command execution fails
@@ -250,7 +273,7 @@ def is_payload_metadata_url_accessible(release: str) -> bool:
     else:
         logger.error(f"Can not get payload pullspec from release stream 4-stable, http error {resp.status_code}")
         return False
-    
+
     # get metadata url from release payload
     # this logic replies on oc client, so need to check oc installation first.
     try:
@@ -259,7 +282,7 @@ def is_payload_metadata_url_accessible(release: str) -> bool:
     except (CalledProcessError, FileNotFoundError):
         logger.error("Cannot find oc client from localhost, please make sure it is installed")
         return False
-    
+
     metadata_url = None
     try:
         cmd = ['oc', 'adm', 'release', 'info', pullspec, '-o', 'json']
@@ -268,7 +291,7 @@ def is_payload_metadata_url_accessible(release: str) -> bool:
     except CalledProcessError as cpe:
         logger.error(f"Execute oc command failed: {str(cpe)}")
         return False
-    
+
     # check if the metadata url is accessible, expected is 200 ok
     logger.info(f"Checking accessiblity of metadata url {metadata_url}")
     try:

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -129,28 +129,28 @@ def is_valid_email(email):
 
 def parse_mr_url(url: str) -> tuple:
     """Parse MR URL to extract project and MR ID
-    
+
     Args:
         url: MR URL in format https://gitlab.cee.redhat.com/namespace/project/-/merge_requests/123
-        
+
     Returns:
         tuple: (project_path, mr_id)
-        
+
     Raises:
         ValueError: If URL is invalid
     """
     parsed = urlparse(url)
     if not parsed.netloc or not parsed.path:
         raise ValueError("Invalid MR URL")
-        
+
     # Extract project path (namespace/project)
     path_parts = parsed.path.split('/-/merge_requests/')
     if len(path_parts) != 2:
         raise ValueError("Invalid MR URL format")
-        
+
     project_path = path_parts[0].strip('/')
     mr_id = int(path_parts[1].split('/')[0])
-    
+
     return (project_path, mr_id)
 
 def get_ocp_test_result_url(release: str) -> str:

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -12,7 +12,6 @@ from subprocess import CalledProcessError
 from requests.exceptions import RequestException
 
 from oar.core.const import LOG_FORMAT, LOG_DATE_FORMAT, TASK_DISPLAY_NAMES, ENV_VAR_JIRA_USERNAME
-from oar.core.exceptions import ConfigStoreException
 
 logger = logging.getLogger(__name__)
 
@@ -237,7 +236,7 @@ def get_elliott_env():
         dict: Copy of os.environ with JIRA_EMAIL set to JIRA_USERNAME if JIRA_EMAIL was not present
 
     Raises:
-        ConfigStoreException: If JIRA_USERNAME environment variable is not set
+        RuntimeError: If JIRA_USERNAME environment variable is not set
 
     Example:
         >>> import subprocess
@@ -247,8 +246,10 @@ def get_elliott_env():
     # TODO: Remove this entire function once OCPERT-389 is fixed in Elliott
     env = os.environ.copy()
     if ENV_VAR_JIRA_USERNAME not in env:
-        raise ConfigStoreException(
-            f"system environment variable {ENV_VAR_JIRA_USERNAME} not found"
+        raise RuntimeError(
+            "JIRA_USERNAME environment variable is not set. "
+            "This is required for elliott to prevent silent failures when querying JIRA. "
+            "Please set JIRA_USERNAME to your JIRA username."
         )
 
     if "JIRA_EMAIL" not in env:

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -229,7 +229,10 @@ def get_elliott_env():
     This function sets JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure.
 
     Returns:
-        dict: Copy of os.environ with JIRA_EMAIL set if JIRA_USERNAME exists
+        dict: Copy of os.environ with JIRA_EMAIL set to JIRA_USERNAME
+
+    Raises:
+        RuntimeError: If JIRA_USERNAME environment variable is not set
 
     Example:
         >>> import subprocess
@@ -239,9 +242,15 @@ def get_elliott_env():
     import os
 
     env = os.environ.copy()
-    if "JIRA_USERNAME" in env:
-        env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
-        logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
+    if "JIRA_USERNAME" not in env:
+        raise RuntimeError(
+            "JIRA_USERNAME environment variable is not set. "
+            "This is required for elliott to prevent silent failures when querying JIRA. "
+            "Please set JIRA_USERNAME to your JIRA username."
+        )
+
+    env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
+    logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
 
     return env
 

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import requests
 import warnings
 import re
@@ -239,8 +240,6 @@ def get_elliott_env():
         >>> cmd = ['elliott', 'find-bugs', '--cve-only']
         >>> p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=get_elliott_env())
     """
-    import os
-
     env = os.environ.copy()
     if "JIRA_USERNAME" not in env:
         raise RuntimeError(

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -11,7 +11,8 @@ from urllib.parse import urlparse
 from subprocess import CalledProcessError
 from requests.exceptions import RequestException
 
-from oar.core.const import LOG_FORMAT, LOG_DATE_FORMAT, TASK_DISPLAY_NAMES
+from oar.core.const import LOG_FORMAT, LOG_DATE_FORMAT, TASK_DISPLAY_NAMES, ENV_VAR_JIRA_USERNAME
+from oar.core.exceptions import ConfigStoreException
 
 logger = logging.getLogger(__name__)
 
@@ -227,29 +228,32 @@ def get_elliott_env():
     """Get environment dict with Elliott JIRA workaround applied.
 
     WORKAROUND: OCPERT-389 - Elliott silently returns empty results when JIRA_EMAIL is not set.
-    This function sets JIRA_EMAIL to JIRA_USERNAME for elliott to prevent silent failure.
+    This function sets JIRA_EMAIL to JIRA_USERNAME as a fallback when JIRA_EMAIL is not already set.
+
+    TODO: Remove this workaround once OCPERT-389 is fixed in Elliott.
+          After the fix, callers should use os.environ.copy() directly instead of this function.
 
     Returns:
-        dict: Copy of os.environ with JIRA_EMAIL set to JIRA_USERNAME
+        dict: Copy of os.environ with JIRA_EMAIL set to JIRA_USERNAME if JIRA_EMAIL was not present
 
     Raises:
-        RuntimeError: If JIRA_USERNAME environment variable is not set
+        ConfigStoreException: If JIRA_USERNAME environment variable is not set
 
     Example:
         >>> import subprocess
         >>> cmd = ['elliott', 'find-bugs', '--cve-only']
         >>> p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=get_elliott_env())
     """
+    # TODO: Remove this entire function once OCPERT-389 is fixed in Elliott
     env = os.environ.copy()
-    if "JIRA_USERNAME" not in env:
-        raise RuntimeError(
-            "JIRA_USERNAME environment variable is not set. "
-            "This is required for elliott to prevent silent failures when querying JIRA. "
-            "Please set JIRA_USERNAME to your JIRA username."
+    if ENV_VAR_JIRA_USERNAME not in env:
+        raise ConfigStoreException(
+            f"system environment variable {ENV_VAR_JIRA_USERNAME} not found"
         )
 
-    env["JIRA_EMAIL"] = env["JIRA_USERNAME"]
-    logger.debug(f"Setting JIRA_EMAIL={env['JIRA_USERNAME']} for elliott")
+    if "JIRA_EMAIL" not in env:
+        env["JIRA_EMAIL"] = env[ENV_VAR_JIRA_USERNAME]
+        logger.debug("Using JIRA_USERNAME as fallback for JIRA_EMAIL")
 
     return env
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 import unittest
+import os
 from unittest.mock import patch
-from oar.core.util import is_payload_metadata_url_accessible
+from oar.core.util import is_payload_metadata_url_accessible, get_elliott_env
 
 class TestPayloadMetadataUrlAccessible(unittest.TestCase):
 
@@ -26,6 +27,38 @@ class TestPayloadMetadataUrlAccessible(unittest.TestCase):
         mock_subprocess.side_effect = FileNotFoundError()
 
         self.assertFalse(is_payload_metadata_url_accessible("4.19"))
+
+
+class TestGetElliottEnv(unittest.TestCase):
+
+    @patch.dict(os.environ, {'JIRA_USERNAME': 'test_user', 'OTHER_VAR': 'value'}, clear=True)
+    def test_happy_path(self):
+        """Test successful case when JIRA_USERNAME is set"""
+        env = get_elliott_env()
+
+        # Should set JIRA_EMAIL to JIRA_USERNAME
+        self.assertEqual(env['JIRA_EMAIL'], 'test_user')
+        # Should preserve existing environment variables
+        self.assertEqual(env['JIRA_USERNAME'], 'test_user')
+        self.assertEqual(env['OTHER_VAR'], 'value')
+
+    @patch.dict(os.environ, {'OTHER_VAR': 'value'}, clear=True)
+    def test_missing_jira_username(self):
+        """Test failure when JIRA_USERNAME is not set"""
+        with self.assertRaises(RuntimeError) as context:
+            get_elliott_env()
+
+        self.assertIn('JIRA_USERNAME environment variable is not set', str(context.exception))
+
+    @patch.dict(os.environ, {'JIRA_USERNAME': 'user@example.com', 'JIRA_EMAIL': 'old@example.com'}, clear=True)
+    def test_overwrite_existing_jira_email(self):
+        """Test that JIRA_EMAIL is overwritten even if it already exists"""
+        env = get_elliott_env()
+
+        # Should overwrite existing JIRA_EMAIL with JIRA_USERNAME
+        self.assertEqual(env['JIRA_EMAIL'], 'user@example.com')
+        self.assertEqual(env['JIRA_USERNAME'], 'user@example.com')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from unittest.mock import patch
 from oar.core.util import is_payload_metadata_url_accessible, get_elliott_env
+from oar.core.exceptions import ConfigStoreException
 
 class TestPayloadMetadataUrlAccessible(unittest.TestCase):
 
@@ -45,18 +46,18 @@ class TestGetElliottEnv(unittest.TestCase):
     @patch.dict(os.environ, {'OTHER_VAR': 'value'}, clear=True)
     def test_missing_jira_username(self):
         """Test failure when JIRA_USERNAME is not set"""
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(ConfigStoreException) as context:
             get_elliott_env()
 
-        self.assertIn('JIRA_USERNAME environment variable is not set', str(context.exception))
+        self.assertIn('JIRA_USERNAME', str(context.exception))
 
     @patch.dict(os.environ, {'JIRA_USERNAME': 'user@example.com', 'JIRA_EMAIL': 'old@example.com'}, clear=True)
-    def test_overwrite_existing_jira_email(self):
-        """Test that JIRA_EMAIL is overwritten even if it already exists"""
+    def test_preserve_existing_jira_email(self):
+        """Test that existing JIRA_EMAIL is preserved and not overwritten"""
         env = get_elliott_env()
 
-        # Should overwrite existing JIRA_EMAIL with JIRA_USERNAME
-        self.assertEqual(env['JIRA_EMAIL'], 'user@example.com')
+        # Should preserve existing JIRA_EMAIL and not overwrite with JIRA_USERNAME
+        self.assertEqual(env['JIRA_EMAIL'], 'old@example.com')
         self.assertEqual(env['JIRA_USERNAME'], 'user@example.com')
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,6 @@ import unittest
 import os
 from unittest.mock import patch
 from oar.core.util import is_payload_metadata_url_accessible, get_elliott_env
-from oar.core.exceptions import ConfigStoreException
 
 class TestPayloadMetadataUrlAccessible(unittest.TestCase):
 
@@ -46,7 +45,7 @@ class TestGetElliottEnv(unittest.TestCase):
     @patch.dict(os.environ, {'OTHER_VAR': 'value'}, clear=True)
     def test_missing_jira_username(self):
         """Test failure when JIRA_USERNAME is not set"""
-        with self.assertRaises(ConfigStoreException) as context:
+        with self.assertRaises(RuntimeError) as context:
             get_elliott_env()
 
         self.assertIn('JIRA_USERNAME', str(context.exception))


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPERT-389
This is workaround. We need to fix it on the Elliott side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CVE tracking and shipment workflows now reliably use an explicit environment configuration, preventing silent empty results and providing a clear error when required credentials are missing.
* **Tests**
  * Added tests to validate the environment helper behavior, including correct derivation and error handling for missing credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->