### PR TITLE
OCPERT-328: Fix UTC logging timestamps across entire codebase

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -128,10 +128,13 @@ from job.controller import (
     update_retried_job_run as jobctl_update_retried_cmd
 )
 
-# Setup logging
+# Setup logging with UTC time
+logging.Formatter.converter = time.gmtime
+
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%dT%H:%M:%SZ'
 )
 logger = logging.getLogger(__name__)
 

--- a/oar/core/log_capture.py
+++ b/oar/core/log_capture.py
@@ -37,7 +37,7 @@ import threading
 from contextlib import contextmanager
 from typing import Iterator
 
-from oar.core.const import LOG_FORMAT, LOG_DATE_FORMAT
+from oar.core import util
 
 
 class ThreadFilter(logging.Filter):
@@ -126,10 +126,7 @@ def capture_logs(thread_safe: bool = False) -> Iterator[io.StringIO]:
     root_logger = logging.getLogger()
     log_handler.setLevel(root_logger.level)
 
-    log_handler.setFormatter(logging.Formatter(
-        fmt=LOG_FORMAT,
-        datefmt=LOG_DATE_FORMAT
-    ))
+    log_handler.setFormatter(util.create_utc_formatter())
 
     # Add ThreadFilter if thread-safe mode enabled
     if thread_safe:

--- a/oar/core/operators.py
+++ b/oar/core/operators.py
@@ -202,7 +202,7 @@ class ApprovalOperator:
 
         # Add the capture handler to the logger
         capture_handler = LogCaptureHandler()
-        capture_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+        capture_handler.setFormatter(util.create_utc_formatter())
         capture_handler.setLevel(logging.DEBUG)  # Capture all log levels
         logger.addHandler(capture_handler)
         

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -5,6 +5,7 @@ import warnings
 import re
 import subprocess
 import json
+import time
 from datetime import datetime, timezone
 from semver.version import Version
 from urllib.parse import urlparse
@@ -81,7 +82,33 @@ def get_release_key(version):
             return prerelease
     return version
 
+def create_utc_formatter(fmt=None, datefmt=None) -> logging.Formatter:
+    """
+    Create a logging formatter that uses UTC time.
+
+    Use this when creating custom handlers (StreamHandler, custom handlers, etc.)
+    to ensure consistent UTC timestamps across all log outputs.
+
+    Args:
+        fmt: Format string (defaults to LOG_FORMAT from const.py)
+        datefmt: Date format string (defaults to LOG_DATE_FORMAT from const.py)
+
+    Returns:
+        logging.Formatter with UTC time conversion
+    """
+    if fmt is None:
+        fmt = LOG_FORMAT
+    if datefmt is None:
+        datefmt = LOG_DATE_FORMAT
+
+    formatter = logging.Formatter(fmt, datefmt)
+    formatter.converter = time.gmtime  # Force UTC time
+    return formatter
+
 def init_logging(log_level=logging.INFO):
+    # Force logging to use UTC time
+    logging.Formatter.converter = time.gmtime
+
     logging.basicConfig(
         format=LOG_FORMAT,
         datefmt=LOG_DATE_FORMAT,

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -6,6 +6,7 @@ import os
 import re
 import shlex
 import subprocess
+import time
 from subprocess import CalledProcessError
 
 import click
@@ -939,6 +940,9 @@ def validate_environment(required_env_vars):
 @click.group()
 @click.option("--debug/--no-debug", help="enable debug logging")
 def cli(debug):
+    # Force logging to use UTC time
+    logging.Formatter.converter = time.gmtime
+
     logging.basicConfig(
         format="%(asctime)s: %(levelname)s: %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%SZ",

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,15 +4,12 @@ import os
 import unittest
 
 import yaml
-
 from job.artifacts import Artifacts
 from job.sippy import Sippy
 
-logging.basicConfig(
-    format="%(asctime)s: %(levelname)s: %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%SZ",
-    level=logging.DEBUG
-)
+from tests import test_util
+
+test_util.setup_utc_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -6,11 +6,9 @@ import oar.core.util as util
 from oar.core.configstore import ConfigStore
 from oar.core.notification import NotificationManager, NotificationException
 from oar.core.worksheet import WorksheetManager
+from tests import test_util
 
-logging.basicConfig(
-    level=logging.DEBUG,  # Set the minimum log level to DEBUG
-    format="%(asctime)s - %(levelname)s - %(message)s",  # Format for log messages
-)
+test_util.setup_utc_logging()
 
 class TestNotificationManager(unittest.TestCase):
     def setUp(self):

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -6,11 +6,9 @@ import unittest
 
 from job.selector import AutoReleaseJobs, TestJobRegistryUpdater
 
-logging.basicConfig(
-    format="%(asctime)s: %(levelname)s: %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%SZ",
-    level=logging.DEBUG
-)
+from tests import test_util
+
+test_util.setup_utc_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_sippy.py
+++ b/tests/test_sippy.py
@@ -11,12 +11,9 @@ from prow.job.sippy import (
     FilterBuilder,
     DatetimePicker,
     StartEndTimePicker)
+from tests import test_util
 
-logging.basicConfig(
-    format="%(asctime)s: %(levelname)s: %(message)s",
-    datefmt="%Y-%m-%dT%H:%M:%SZ",
-    level=logging.DEBUG
-)
+test_util.setup_utc_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,26 @@
 import unittest
 import os
+import logging
+import time
 from unittest.mock import patch
 from oar.core.util import is_payload_metadata_url_accessible, get_elliott_env
+
+
+def setup_utc_logging(level=logging.DEBUG):
+    """
+    Configure logging to use UTC timestamps for test execution.
+
+    Args:
+        level: Logging level (default: logging.DEBUG)
+    """
+    # Force logging to use UTC time
+    logging.Formatter.converter = time.gmtime
+
+    logging.basicConfig(
+        format="%(asctime)s: %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%SZ",
+        level=level
+    )
 
 class TestPayloadMetadataUrlAccessible(unittest.TestCase):
 

--- a/tools/ci_job_failure_fetcher.py
+++ b/tools/ci_job_failure_fetcher.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import sys
+import time
 import tarfile
 from collections import defaultdict
 from typing import Dict, List, Tuple, Optional
@@ -576,7 +577,8 @@ class CIJobFailureFetcher:
 
 def main():
     """Main entry point for CLI usage"""
-    # Initialize logging
+    # Initialize logging with UTC time
+    logging.Formatter.converter = time.gmtime
     logging.basicConfig(
         format="%(asctime)s: %(levelname)s: %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%SZ",


### PR DESCRIPTION
Logs showed inconsistent timezones across VM, StateBox YAML files, local dev environments, and Slack threads, making it difficult to correlate timing of related events.

All log timestamps now use UTC time consistently.

https://redhat.atlassian.net/browse/OCPERT-328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized logging timestamps to use UTC consistently across all application components and tests, ensuring all system logs display time in the same timezone regardless of server location or system configuration, improving reliability and ease of debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->