### PR TITLE
OCPERT-368: Replace GitHub token with Github app for ERT dashboard

### DIFF
--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -3,7 +3,8 @@ import os
 
 import pandas as pd
 import streamlit as st
-from github import Github, Auth
+
+from oar.core.github_app import GitHubApp
 
 # Define the github access variables
 repository_owner = 'openshift'
@@ -11,15 +12,16 @@ repository_name = 'release-tests'
 directory_path = '_releases'
 branch_name = 'record'
 
-# Read the GitHub token from a system environment variable
-github_token = os.environ.get('GITHUB_TOKEN')
-if not github_token:
-    st.warning("Oops, ENV VAR GITHUB_TOKEN NOT FOUND")
+# Read the GitHub App credentials from environment variables
+github_app_id = os.environ.get('GITHUB_APP_WRITER_ID')
+github_app_private_key = os.environ.get('GITHUB_APP_WRITER_PRIVATE_KEY')
+if not github_app_id or not github_app_private_key:
+    st.warning("Oops, ENV VAR GITHUB_APP_WRITER_ID or GITHUB_APP_WRITER_PRIVATE_KEY NOT FOUND")
     st.stop()
 
-
-# Create a GitHub instance with the token
-gh = Github(auth=Auth.Token(github_token))
+# Create a GitHub instance with the App installation token
+gh = GitHubApp(github_app_id, github_app_private_key).client_for_repo(
+    repository_owner, repository_name)
 
 # Get the repository object
 repo = gh.get_repo(f'{repository_owner}/{repository_name}')

--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 
 import pandas as pd
 import streamlit as st
 
 from oar.core.github_app import GitHubApp
+
+logger = logging.getLogger(__name__)
 
 # Define the github access variables
 repository_owner = 'openshift'
@@ -20,8 +23,17 @@ if not github_app_id or not github_app_private_key:
     st.stop()
 
 # Create a GitHub instance with the App installation token
-gh = GitHubApp(github_app_id, github_app_private_key).client_for_repo(
-    repository_owner, repository_name)
+try:
+    gh = GitHubApp(github_app_id, github_app_private_key).client_for_repo(
+        repository_owner, repository_name)
+except Exception:
+    logger.exception("Failed to initialize GitHub App client")
+    st.error(
+        "Failed to initialize GitHub App client. "
+        "Please check `GITHUB_APP_WRITER_ID` and `GITHUB_APP_WRITER_PRIVATE_KEY` "
+        "and verify the app is installed on `openshift/release-tests`."
+    )
+    st.stop()
 
 # Get the repository object
 repo = gh.get_repo(f'{repository_owner}/{repository_name}')


### PR DESCRIPTION
rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

https://redhat.atlassian.net/browse/OCPERT-368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated authentication for the release test dashboard to an app-based method and added validation with user-facing warnings/errors when configuration is missing or initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->