### PR TITLE
OCPERT-411: Add support for OCP 5 version handling

### DIFF
--- a/.claude/commands/release/drive.md
+++ b/.claude/commands/release/drive.md
@@ -262,7 +262,8 @@ For complete step-by-step logic, refer to the **`release-workflow` skill** (`.cl
 
 **Check promotion status:**
 ```bash
-curl -s "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/{release}" | jq -r '.phase'
+MAJOR_VERSION=$(echo "{release}" | cut -d. -f1)
+curl -s "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/${MAJOR_VERSION}-stable/release/{release}" | jq -r '.phase'
 ```
 
 **Expected output:**

--- a/.claude/skills/release-workflow/SKILL.md
+++ b/.claude/skills/release-workflow/SKILL.md
@@ -116,7 +116,8 @@ analyze-candidate-build (conditionally - only if accepted == false)
 
 **API Endpoint:**
 ```
-https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/release/{release}
+https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/{major_version}-stable/release/{release}
+# Where {major_version} is extracted from {release} (e.g., "4" from "4.20.1", "5" from "5.0.1")
 ```
 
 **Success Criteria:**

--- a/oar/cli/cmd_image_signed_check.py
+++ b/oar/cli/cmd_image_signed_check.py
@@ -61,9 +61,10 @@ def image_signed_check(ctx):
         # Log in-progress status for cli_result_callback parsing
         util.log_task_status(TASK_IMAGE_SIGNED_CHECK, TASK_STATUS_INPROGRESS)
 
+        major_version = util.get_major_version(cs.release)
         release_url = (
             cs.get_release_url()
-            + "api/v1/releasestream/4-stable/release/"
+            + f"api/v1/releasestream/{major_version}-stable/release/"
             + cs.release
         )
         digest_sha = get_image_digest(release_url)

--- a/oar/controller/detector.py
+++ b/oar/controller/detector.py
@@ -8,6 +8,7 @@ from semver import VersionInfo
 
 from oar.cli.cmd_create_test_report import create_test_report
 from oar.core.configstore import ConfigStore
+from oar.core import util
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,8 @@ class ReleaseDetector:
         """
         Get the latest stable version from release stream
         """
-        url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest?prefix={self._minor_release}"
+        major_version = util.get_major_version(self._minor_release)
+        url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/{major_version}-stable/latest?prefix={self._minor_release}"
         resp = requests.get(url)
         if resp.ok:
             return resp.json()["name"]
@@ -94,7 +96,7 @@ class ReleaseDetector:
 
 
 def validate_minor_release(ctx, param, value):
-    pattern = re.compile(r"^4\.\d{1,2}$")
+    pattern = re.compile(r"^\d+\.\d{1,2}$")
     if not pattern.match(value):
         raise click.BadParameter(f"Invalid OCP minor version {value}")
     return value

--- a/oar/core/util.py
+++ b/oar/core/util.py
@@ -36,6 +36,20 @@ def get_y_release(version):
 
     return None
 
+def get_major_version(version):
+    """
+    Get major version from release string.
+
+    Supports both Y-stream (e.g., "4.19") and Z-stream (e.g., "5.0.1") formats.
+
+    Args:
+        version: Release version string
+
+    Returns:
+        str: Major version (e.g., "4", "5")
+    """
+    return version.split(".")[0]
+
 def validate_release_version(version):
     try:
         Version.parse(version)
@@ -304,14 +318,15 @@ def is_payload_metadata_url_accessible(release: str) -> bool:
         requests.exceptions.RequestException: If any HTTP request fails
         subprocess.CalledProcessError: If oc command execution fails
     """
-    # get image pullspec from release stream 4-stable
+    # Get image pullspec from release stream (e.g., 4-stable, 5-stable)
     pullspec = None
-    url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest?prefix={release}"
+    major_version = get_major_version(release)
+    url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/{major_version}-stable/latest?prefix={release}"
     resp = requests.get(url)
     if resp.ok:
         pullspec = resp.json()['pullSpec']
     else:
-        logger.error(f"Can not get payload pullspec from release stream 4-stable, http error {resp.status_code}")
+        logger.error(f"Can not get payload pullspec from release stream {major_version}-stable, http error {resp.status_code}")
         return False
 
     # get metadata url from release payload

--- a/prow/job/controller.py
+++ b/prow/job/controller.py
@@ -16,6 +16,7 @@ from github import Auth, Github
 from github.GithubException import UnknownObjectException, GithubException
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
+from semver import VersionInfo
 from urllib3 import Retry
 
 from .artifacts import Artifacts
@@ -51,6 +52,20 @@ def create_session() -> requests.Session:
     return session
 
 
+def get_y_stream_version(version):
+    """
+    Extract Y-stream version (major.minor) from full build version.
+
+    Args:
+        version: Full build version (e.g., "5.0.1", "5.0.0-0.nightly-2026-06-01-123456")
+
+    Returns:
+        Y-stream version (e.g., "5.0", "4.16")
+    """
+    v = VersionInfo.parse(version)
+    return f"{v.major}.{v.minor}"
+
+
 class Architectures():
 
     AMD64 = "amd64"
@@ -76,8 +91,17 @@ class Architectures():
 
 
 class ReleaseStreamURLResolver():
+    """Resolves OpenShift release stream URLs."""
 
     def __init__(self, release, nightly=True, arch=Architectures.AMD64):
+        """
+        Initialize ReleaseStreamURLResolver.
+
+        Args:
+            release: Y-stream version (e.g., "5.0", "4.16")
+            nightly: True for nightly builds, False for stable builds
+            arch: Architecture (amd64, arm64, ppc64le, s390x, multi)
+        """
         self._arch = Architectures.fromString(arch)
         self._nightly = nightly
         self._release = release
@@ -86,8 +110,9 @@ class ReleaseStreamURLResolver():
     def get_url_for_latest(self):
         base_url = f"https://{self._arch}.ocp.releases.ci.openshift.org/api/v1/releasestream"
         suffix = "" if self._arch == Architectures.AMD64 else f"-{self._arch}"
+        major_version = self._release.split(".")[0]
         releasestream = (
-            f"{self._release}.0-0.nightly" if self._nightly else f"4-stable") + suffix
+            f"{self._release}.0-0.nightly" if self._nightly else f"{major_version}-stable") + suffix
 
         if self._nightly:
             url = f"{base_url}/{releasestream}/latest"
@@ -95,7 +120,7 @@ class ReleaseStreamURLResolver():
             url = f"{base_url}/{releasestream}/latest?prefix={self._release}"
             # if stable build is not available for latest release, use dev preview releasestream instead
             if self._session.get(url).status_code == 404:
-                releasestream = "4-dev-preview" + suffix
+                releasestream = f"{major_version}-dev-preview" + suffix
                 url = f"{base_url}/{releasestream}/latest"
 
         return url
@@ -105,14 +130,14 @@ class ReleaseStreamURLResolver():
         # the arch can be found in build string of nightly
         # but it does not work for stable build, so param arch is needed here.
         url_resolver = ReleaseStreamURLResolver(
-            build[:4], "nightly" in build, arch)
+            get_y_stream_version(build), "nightly" in build, arch)
 
         return url_resolver.get_url_for_latest().replace("latest", f"release/{build}")
 
     @staticmethod
     def get_url_for_tags(build, arch):
         url_resolver = ReleaseStreamURLResolver(
-            build[:4], "nightly" in build, arch)
+            get_y_stream_version(build), "nightly" in build, arch)
         return url_resolver.get_url_for_latest().replace("latest", "tags")
 
 
@@ -205,10 +230,19 @@ class TestJob():
 
 
 class JobController:
+    """Controls Prow job execution for OpenShift builds."""
 
     def __init__(self, release, nightly=True, trigger_prow_job=True, arch=Architectures.AMD64):
-        self._release = release[:-
-                                2] if len(release.split(".")) == 3 else release
+        """
+        Initialize JobController.
+
+        Args:
+            release: Y-stream version (e.g., "5.0", "4.16")
+            nightly: True for nightly builds, False for stable builds
+            trigger_prow_job: Whether to trigger Prow jobs when new builds are found
+            arch: Architecture (amd64, arm64, ppc64le, s390x, multi)
+        """
+        self._release = release
         self._nightly = nightly
         self._trigger_prow_job = trigger_prow_job
         self._arch = Architectures.fromString(arch)
@@ -456,6 +490,7 @@ class TestJobRegistry():
             matched_path = re.search(
                 r'ocp-\d\.\d+-test-jobs-{}.json'.format(self._arch), content.path)
             if matched_path:
+                # Get y-stream release version
                 release = re.search(r'\d\.\d+', matched_path.group()).group()
                 file_content = self.release_tests_main.get_file_content(
                     content.path)
@@ -467,7 +502,16 @@ class TestJobRegistry():
         logger.info("Test job registry is initialized")
 
     def get_test_jobs(self, release, nightly):
+        """
+        Get all test jobs for a given release stream.
 
+        Args:
+            release: Y-stream version (e.g., "5.0", "4.16")
+            nightly: True for nightly builds, False for stable builds
+
+        Returns:
+            List of TestJob
+        """
         test_jobs = []
         build_type = JOB_TYPE_NIGHTLY if nightly else JOB_TYPE_STABLE
         if release not in self._registry:
@@ -482,7 +526,17 @@ class TestJobRegistry():
         return test_jobs
 
     def get_test_job(self, release, nightly, job_name):
+        """
+        Get a specific test job by name for a given release stream.
 
+        Args:
+            release: Y-stream version (e.g., "5.0", "4.16")
+            nightly: True for nightly builds, False for stable builds
+            job_name: Prow job name to find
+
+        Returns:
+            TestJob if found, None otherwise
+        """
         test_job = None
         jobs = self.get_test_jobs(release, nightly)
         if len(jobs):
@@ -744,6 +798,7 @@ class TestResultAggregator():
             if matched_path:
                 file_name = matched_path.group()
                 logger.info(f"Found test result file {file_name}")
+                # Get y-stream release version
                 release = re.search(r'\d\.\d+', file_name).group()
                 # check if the build is nightly
                 nightly = "nightly" in file_name
@@ -966,7 +1021,7 @@ def start_controller(release, nightly, trigger_prow_job, arch):
 @click.option("--skip-existing/--no-skip-existing", help="skip jobs that are already triggered (default: enabled)", default=True)
 def trigger_jobs_for_build(build, arch, skip_existing):
     validate_environment(REQUIRED_ENV_VARS_FOR_CONTROLLER)
-    release = build[:4]
+    release = get_y_stream_version(build)
     nightly = "nightly" in build
     controller = JobController(release, nightly, True, arch)
     build_obj = controller.get_build(build)

--- a/prow/job/job.py
+++ b/prow/job/job.py
@@ -30,7 +30,7 @@ class Jobs:
     STAGE_TESTING_JOB_NAME_TEMPLATE = "periodic-ci-openshift-openshift-tests-private-release-{minor_release}-stage-testing-e2e-aws-ipi"
 
     def __init__(self):
-        self.url = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags"
+        self.url = "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/tags" # TODO to be updated to support 5-stable, or to be removed
         # config the based URL here
         self.job_url = "https://api.github.com/repos/openshift/release/contents/ci-operator/config/openshift/openshift-tests-private/{}?ref=main"
         self.gangway_url = "https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com/v1/executions/"
@@ -66,7 +66,7 @@ class Jobs:
     # see bug: https://issues.redhat.com/browse/DPTP-3538, https://issues.redhat.com/browse/OCPQE-17600
     def get_amd_image_for_arm(self, payload):
         """Function get amd64 image as the ARM platform base image"""
-        version_pattern = re.compile(r':(\d*\.\d{2}\.\d)(-.*)?-')
+        version_pattern = re.compile(r':(\d+\.\d+\.\d+)(-.*)?-')
         version = version_pattern.findall(payload)
         if len(version) > 0:
             version_string = "".join(version[0])
@@ -747,6 +747,7 @@ def run_required(channel, file, version):
     help="push the info to the https://api.github.com/repos/openshift/release-tests/contents/_releases/",
 )
 def run_payloads(versions, push):
+    # TODO Remove if not used, ref: https://redhat.atlassian.net/browse/OCPERT-418
     """Check the latest stable payload of each version. Use comma spacing if multi versions, such as, 4.10.0,4.11.0,4.12.0"""
     JOB.get_payloads(versions, push)
 

--- a/tools/check_stage_bundle_images.sh
+++ b/tools/check_stage_bundle_images.sh
@@ -43,10 +43,10 @@ fi
 
 OCP_VERSION="$1"
 
-# Validate version format (should be like 4.19, 4.20, etc.)
-if ! echo "$OCP_VERSION" | grep -qE '^4\.[0-9]+$'; then
+# Validate version format (should be like 4.19, 5.0, etc.)
+if ! echo "$OCP_VERSION" | grep -qE '^[0-9]+\.[0-9]+$'; then
   echo "Error: Invalid OCP version format: $OCP_VERSION"
-  echo "Expected format: 4.XX (e.g., 4.19, 4.20)"
+  echo "Expected format: X.Y (e.g., 4.19, 5.0)"
   exit 1
 fi
 


### PR DESCRIPTION
Enable all version-dependent logic to work with OCP 5.x and future versions by replacing hardcoded 4.x patterns with dynamic version handling.

- Update version extraction and parsing to handle any version
- Update validation patterns to accept any version
- Make release stream URL construction dynamic
- Update Claude Code commands

https://redhat.atlassian.net/browse/OCPERT-411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows now support all major release versions, not limited to version 4.x.

* **Bug Fixes**
  * Fixed release promotion status checks to correctly query the appropriate release stream for any version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->