### PR TITLE
OCPERT-412 Enable auto release jobs for 5.0

### DIFF
--- a/_releases/ocp-5.0-test-jobs-amd64.json
+++ b/_releases/ocp-5.0-test-jobs-amd64.json
@@ -1,0 +1,38 @@
+{
+  "nightly": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-aws-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-azure-ipi-fips-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-gcp-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-aws-ipi-disruptive-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-stable-5.0-upgrade-from-stable-4.22-gcp-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-nightly-5.0-upgrade-from-stable-5.0-aws-ipi-f999",
+      "upgrade": true
+    }
+  ],
+  "stable": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-stable-5.0-upgrade-from-stable-4.22-aws-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-stable-5.0-upgrade-from-stable-5.0-azure-ipi-fips-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-stable-5.0-upgrade-from-stable-5.0-gcp-ipi-f999",
+      "upgrade": true
+    }
+  ]
+}

--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -120,7 +120,7 @@ cola, colb = st.columns(2, vertical_alignment='bottom')
 with cola:
     release = st.selectbox(
         'Choose minor release',
-        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22")
+        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22", "5.0")
     )
 # clear cache manually if you want to get latest results
 with colb:


### PR DESCRIPTION
- Add test job registry config for 5.0 auto release jobs
- Enable 5.0 in auto release test dashboard

https://redhat.atlassian.net/browse/OCPERT-412

Depends on https://github.com/openshift/release/pull/79928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift Container Platform 5.0 as a new selectable release version in the release dashboard.

* **Chores**
  * Configured automated test job definitions for OCP 5.0 release pipelines, supporting both nightly and stable release channels with integrated upgrade testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->