### PR TITLE
OCPERT-419:Fix component-monitor config to use localhost instead of hardcoded IP

### DIFF
--- a/deployment/component-monitor/config.yaml
+++ b/deployment/component-monitor/config.yaml
@@ -3,7 +3,7 @@ components:
   - component_slug: "errata-reliability"
     sub_component_slug: "mcp-server"
     http_monitor:
-      url: "http://10.0.76.71:8000/health"
+      url: "http://localhost:8000/health" #Use localhost because component-monitor and mcp-server runs on the same server
       code: 200
       retry_after: 5s
       severity: "Down"

--- a/deployment/systemd/ship-status-component-monitor.service
+++ b/deployment/systemd/ship-status-component-monitor.service
@@ -8,6 +8,7 @@ Type=simple
 
 ExecStartPre=-/usr/bin/podman pull quay.io/openshiftci/component-monitor:latest
 ExecStart=/usr/bin/podman run --rm --replace --name ship-status-component-monitor \
+    --network host \
     --security-opt label=disable \
     -v /home/cloud-user/release-tests/deployment/component-monitor/config.yaml:/config.yaml:ro \
     -v /etc/component-monitor/token.txt:/token.txt:ro \


### PR DESCRIPTION
JIRA: https://redhat.atlassian.net/browse/OCPERT-419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated health-check endpoint to use a localhost address to support co-located monitoring during local runs.
  * Adjusted the service startup to enable host networking for the monitoring container, improving local connectivity for health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->