### PR TITLE
OCPERT-411 Fix auto release test dashboard version substring matching

### DIFF
--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -94,7 +94,7 @@ def load_test_results(release='4.12'):
         path=directory_path, ref=branch_name)
     table_data = []
     for file in directory_contents:
-        if file.name.startswith('ocp-test-result') and release in file.name:
+        if file.name.startswith('ocp-test-result') and f'-{release}.' in file.name:
             try:
                 file_content = json.loads(file.decoded_content.decode('utf-8'))
                 job_summary, job_links = get_col_test_summary(file_content)


### PR DESCRIPTION
Filtering for '5.0' was showing '4.15.0' builds due to substring overlap.

https://redhat.atlassian.net/browse/OCPERT-411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved accuracy of test result filtering in internal release testing tools to ensure more precise test data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->