### PR TITLE
[OCPERT-394] Add 4.23 test job registry and enable in dashboard

### DIFF
--- a/_releases/ocp-4.23-test-jobs-amd64.json
+++ b/_releases/ocp-4.23-test-jobs-amd64.json
@@ -1,0 +1,38 @@
+{
+  "nightly": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-aws-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-azure-ipi-fips-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-gcp-ipi-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-aws-ipi-disruptive-f999"
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-stable-4.23-upgrade-from-stable-4.22-gcp-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-nightly-4.23-upgrade-from-stable-4.23-aws-ipi-f999",
+      "upgrade": true
+    }
+  ],
+  "stable": [
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-stable-4.23-upgrade-from-stable-4.22-aws-ipi-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-stable-4.23-upgrade-from-stable-4.23-azure-ipi-fips-f999",
+      "upgrade": true
+    },
+    {
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-stable-4.23-upgrade-from-stable-4.23-gcp-ipi-f999",
+      "upgrade": true
+    }
+  ]
+}

--- a/_releases/ocp-4.23-test-jobs-amd64.json
+++ b/_releases/ocp-4.23-test-jobs-amd64.json
@@ -13,7 +13,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-aws-ipi-disruptive-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-stable-4.23-upgrade-from-stable-4.22-gcp-ipi-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-4.23-automated-release-nightly-4.23-upgrade-from-stable-4.22-gcp-ipi-f999",
       "upgrade": true
     },
     {

--- a/tools/auto_release_test_dashboard.py
+++ b/tools/auto_release_test_dashboard.py
@@ -120,7 +120,7 @@ cola, colb = st.columns(2, vertical_alignment='bottom')
 with cola:
     release = st.selectbox(
         'Choose minor release',
-        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22", "5.0")
+        ("4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20", "4.21", "4.22", "4.23", "5.0")
     )
 # clear cache manually if you want to get latest results
 with colb:


### PR DESCRIPTION
JIRA: https://redhat.atlassian.net/browse/OCPERT-394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift Container Platform **4.23** release support to the auto-release test dashboard. Users can now select **4.23** in the minor release dropdown to view nightly and stable test job results, including upgrade-related test runs where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->