### PR TITLE
OCPERT-425: Switch nightly upgrade job to nightly-5.0-upgrade-from-st…

### DIFF
--- a/_releases/ocp-5.0-test-jobs-amd64.json
+++ b/_releases/ocp-5.0-test-jobs-amd64.json
@@ -13,7 +13,7 @@
       "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-aws-ipi-disruptive-f999"
     },
     {
-      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-stable-5.0-upgrade-from-stable-4.22-gcp-ipi-f999",
+      "prowJob": "periodic-ci-openshift-openshift-tests-private-release-5.0-automated-release-nightly-5.0-upgrade-from-stable-4.22-gcp-ipi-f999",
       "upgrade": true
     },
     {


### PR DESCRIPTION
…able-4.22 variant

https://redhat.atlassian.net/browse/OCPERT-425

Depends on https://github.com/openshift/release/pull/81070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a nightly upgrade test job name for the GCP IPI workflow to align with the current nightly release naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->