### PR TITLE
[OCPERT-433] Slack bot: fix whitespace handling in OAR command detection

### DIFF
--- a/tools/slack_message_receiver.py
+++ b/tools/slack_message_receiver.py
@@ -58,7 +58,7 @@ def get_username(user_id):
 
 
 def is_oar_related_message(message):
-    return message.startswith("oar") or message.startswith("oarctl") or re.search("^<\@.*>\ oar\ ", message) or re.search("^<\@.*>\ oarctl\ ", message)
+    return message.startswith("oar") or message.startswith("oarctl") or re.search(r"^<\@.*>\s+oar\s+", message) or re.search(r"^<\@.*>\s+oarctl\s+", message)
 
 
 def validate_oar_command(message):


### PR DESCRIPTION
JIRA: https://redhat.atlassian.net/browse/OCPERT-433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of OAR and OARCTL commands in Slack messages following user mentions.
  * Commands are now recognized with flexible spacing before, after, and between command tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->